### PR TITLE
31 use weighted covariance matrix decomposition

### DIFF
--- a/include/MeshObject/InteriorPoint.hpp
+++ b/include/MeshObject/InteriorPoint.hpp
@@ -92,6 +92,9 @@ private:
 
     FIFOCache<std::size_t, Eigen::Vector3d> buffer_projected_position_{3};
     FIFOCache<std::size_t, double> buffer_projected_distance_{3};
+
+public:
+    double weight_;
 };
 
 bool operator<(const std::shared_ptr<InteriorPoint>& lhs, const std::shared_ptr<InteriorPoint>& rhs);

--- a/include/MeshObject/Settings.hpp
+++ b/include/MeshObject/Settings.hpp
@@ -31,7 +31,8 @@ enum class ColorMode
     SIBLINGS,
     SURFACE_UNCERTAINTY,
     CONTENTION,
-    DISTANCE_TRAVELLED
+    DISTANCE_TRAVELLED,
+    WEIGHT
 };
 
 struct DataLoader_Settings

--- a/include/MeshObject/Surface.hpp
+++ b/include/MeshObject/Surface.hpp
@@ -137,7 +137,7 @@ private:
     Eigen::Vector3d eigenvalues_;
     Eigen::Vector3d normal_;
     double characteristic_length_;
-    double normal_uncertainty_;
+    double normal_uncertainty_ = 0;
     double sum_of_average_distance_travelled_;
     double smallest_distance_travelled_ = std::numeric_limits<double>::max();
 

--- a/include/MeshObject/Surface.hpp
+++ b/include/MeshObject/Surface.hpp
@@ -130,6 +130,7 @@ private:
 
     void add_point_to_surface_fitting(const Eigen::Vector3d& point, const Eigen::Vector3d& origin, double distance_travelled, double projection_uncertainty);
     void remove_point_from_surface_fitting(const Eigen::Vector3d& position, const Eigen::Vector3d& origin, double distance_travelled, double projection_uncertainty);
+    int size_ = 0;
     Eigen::Vector3d mean_;
     Eigen::Matrix3d covariance_;
     Eigen::Matrix3d eigenvectors_;

--- a/include/MeshObject/Surface.hpp
+++ b/include/MeshObject/Surface.hpp
@@ -130,7 +130,7 @@ private:
 
     void add_point_to_surface_fitting(const Eigen::Vector3d& point, const Eigen::Vector3d& origin, double distance_travelled, double projection_uncertainty);
     void remove_point_from_surface_fitting(const Eigen::Vector3d& position, const Eigen::Vector3d& origin, double distance_travelled, double projection_uncertainty);
-    int size_ = 0;
+    double weight_ = 0;
     Eigen::Vector3d mean_;
     Eigen::Matrix3d covariance_;
     Eigen::Matrix3d eigenvectors_;

--- a/include/MeshObject/Surface.hpp
+++ b/include/MeshObject/Surface.hpp
@@ -128,8 +128,8 @@ private:
     std::unordered_set<std::shared_ptr<Face>, MeshObjectHash> faces_;
     std::unordered_set<std::shared_ptr<InteriorPoint>, MeshObjectHash> interior_points_;
 
-    void add_point_to_surface_fitting(const Eigen::Vector3d& point, const Eigen::Vector3d& origin, double distance_travelled);
-    void remove_point_from_surface_fitting(const Eigen::Vector3d& position, const Eigen::Vector3d& origin, double distance_travelled);
+    void add_point_to_surface_fitting(const Eigen::Vector3d& point, const Eigen::Vector3d& origin, double distance_travelled, double projection_uncertainty);
+    void remove_point_from_surface_fitting(const Eigen::Vector3d& position, const Eigen::Vector3d& origin, double distance_travelled, double projection_uncertainty);
     Eigen::Vector3d mean_;
     Eigen::Matrix3d covariance_;
     Eigen::Matrix3d eigenvectors_;

--- a/include/MeshObject/Vertex.hpp
+++ b/include/MeshObject/Vertex.hpp
@@ -154,6 +154,9 @@ private:
     Eigen::Vector3d direction_;
 
     double projected_uncertainty_;
+
+public:
+    double weight_;
 };
 
 bool operator<(const std::shared_ptr<Vertex>& lhs, const std::shared_ptr<Vertex>& rhs);

--- a/include/utilities/covariance_math.hpp
+++ b/include/utilities/covariance_math.hpp
@@ -10,6 +10,16 @@ Eigen::Matrix3d remove_covariance(const Eigen::Matrix3d& combined_covariance, co
                                 const Eigen::Vector3d& combined_mean, const Eigen::Vector3d& mean2, 
                                 int combined_size, int size2);
 
+Eigen::Vector3d weighted_merge_mean(const Eigen::Vector3d& mean1, const Eigen::Vector3d& mean2, double weight1, double weight2);
+Eigen::Matrix3d weighted_merge_covariance(const Eigen::Matrix3d& cov1, const Eigen::Matrix3d& cov2, 
+                                const Eigen::Vector3d& mean1, const Eigen::Vector3d& mean2, 
+                                double weight1, double weight2);
+
+Eigen::Vector3d weighted_remove_mean(const Eigen::Vector3d& combined_mean, const Eigen::Vector3d& mean2, double combined_weight, double weight2);
+Eigen::Matrix3d weighted_remove_covariance(const Eigen::Matrix3d& combined_covariance, const Eigen::Matrix3d& cov2, 
+                                const Eigen::Vector3d& combined_mean, const Eigen::Vector3d& mean2, 
+                                double combined_weight, double weight2);
+
 double merge_information_weighted_mean(const double& mean1, const double& mean2, const double& information1, const double& information2);
 double merge_information(const double& information1, const double& information2);
 

--- a/include/utilities/utilities.hpp
+++ b/include/utilities/utilities.hpp
@@ -17,6 +17,7 @@ bool is_point_in_triangle(const Eigen::Vector2d& a, const Eigen::Vector2d& b, co
 
 Eigen::Matrix3d generate_orthogonal_basis(const Eigen::Vector3d& unit_vector);
 Eigen::Matrix3d generate_unit_vector_covariance(const Eigen::Vector3d& unit_vector, double angular_uncertainty_in_radian, double epsilon);
+Eigen::Matrix3d generate_directional_covariance(const Eigen::Vector3d& direction_vector, double uncertainty_in_direction, double epsilon);
 
 double shortest_distance_to_line_segment(const Eigen::Vector3d& rayOrigin, const Eigen::Vector3d& rayEnd, const Eigen::Vector3d& targetPoint);
 

--- a/src/MeshObject/Application.cpp
+++ b/src/MeshObject/Application.cpp
@@ -940,6 +940,14 @@ pcl::PointCloud<pcl::PointXYZRGB>::Ptr Application<PointT>::compute_interior_poi
             point.g = std::get<1>(color);
             point.b = std::get<2>(color);
         }
+        else if (settings.color_mode == ColorMode::WEIGHT)
+        {
+            double distance = interior_point->weight_ / 10000.f;
+            std::tuple<int, int, int> color = valueToJet(distance);
+            point.r = std::get<0>(color);
+            point.g = std::get<1>(color);
+            point.b = std::get<2>(color);
+        }
         cloud->push_back(point);
     }
     return cloud;
@@ -1080,6 +1088,14 @@ pcl::PointCloud<pcl::PointXYZRGB>::Ptr Application<PointT>::compute_vertex_point
         else if (setting.color_mode == ColorMode::DISTANCE_TRAVELLED)
         {
             double distance = vertex->get_distance_travelled() / 20.f;
+            std::tuple<int, int, int> color = valueToJet(distance);
+            point.r = std::get<0>(color);
+            point.g = std::get<1>(color);
+            point.b = std::get<2>(color);
+        }
+        else if (setting.color_mode == ColorMode::WEIGHT)
+        {
+            double distance = vertex->weight_ / 10000.f;
             std::tuple<int, int, int> color = valueToJet(distance);
             point.r = std::get<0>(color);
             point.g = std::get<1>(color);

--- a/src/MeshObject/InteractiveViewer.cpp
+++ b/src/MeshObject/InteractiveViewer.cpp
@@ -280,6 +280,11 @@ void InteractiveViewer<PointT>::keyboard_callback(const pcl::visualization::Keyb
     // kp numebr 8
     if (event.getKeySym() == "KP_Up" && event.keyDown())
     {
+        settings_.color_mode = ColorMode::WEIGHT;
+        update_display();
+
+        // log
+        std::cout << "color_mode: weight" << std::endl;
     }
     // kp numebr 9
     if (event.getKeySym() == "KP_Prior" && event.keyDown())

--- a/src/MeshObject/Surface.cpp
+++ b/src/MeshObject/Surface.cpp
@@ -1002,7 +1002,7 @@ void Surface::print_info()
 void Surface::add_point_to_surface_fitting(const Eigen::Vector3d& position, const Eigen::Vector3d& origin, double distance_travelled, double projection_uncertainty)
 {
     // surface
-    int size1 = get_total_point_size()-1; // need to exclude the new point
+    int size1 = size_;
     Eigen::Vector3d mean1 = mean_;
     Eigen::Matrix3d cov1 = covariance_;
 
@@ -1014,6 +1014,7 @@ void Surface::add_point_to_surface_fitting(const Eigen::Vector3d& position, cons
     // set + point
     Eigen::Vector3d new_mean = merge_mean(mean1, mean2, size1, size2);
     Eigen::Matrix3d new_cov = merge_covariance(cov1, cov2, mean1, mean2, size1, size2);
+    int new_size = size1 + size2;
 
     // plane estimate
     Eigen::SelfAdjointEigenSolver<Eigen::Matrix3d> solver(new_cov);
@@ -1024,6 +1025,7 @@ void Surface::add_point_to_surface_fitting(const Eigen::Vector3d& position, cons
     if (new_normal.dot(vector_towards_origin) < 0) new_normal *= -1; // normal should points towards the origin
 
     // store
+    size_ = new_size;
     mean_ = new_mean;
     covariance_ = new_cov;
     eigenvectors_ = new_eigenvectors;
@@ -1075,7 +1077,7 @@ void Surface::add_point_to_surface_fitting(const Eigen::Vector3d& position, cons
 void Surface::remove_point_from_surface_fitting(const Eigen::Vector3d& position, const Eigen::Vector3d& origin, double distance_travelled, double projection_uncertainty)
 {
     // surface
-    int combined_size = get_total_point_size()+1; // need to include the point just removed
+    int combined_size = size_;
     Eigen::Vector3d combined_mean = mean_;
     Eigen::Matrix3d combined_cov = covariance_;
 
@@ -1087,6 +1089,7 @@ void Surface::remove_point_from_surface_fitting(const Eigen::Vector3d& position,
     // set + point
     Eigen::Vector3d mean1 = remove_mean(combined_mean, mean2, combined_size, size2);
     Eigen::Matrix3d cov1 = remove_covariance(combined_cov, cov2, combined_mean, mean2, combined_size, size2);
+    int size1 = combined_size - size2;
 
     // plane estimate
     Eigen::SelfAdjointEigenSolver<Eigen::Matrix3d> solver(cov1);
@@ -1096,6 +1099,8 @@ void Surface::remove_point_from_surface_fitting(const Eigen::Vector3d& position,
     Eigen::Vector3d vector_towards_origin = origin - position;
     if (normal1.dot(vector_towards_origin) < 0) normal1 *= -1; // normal should points towards the origin
 
+    // store
+    size_ = size1;
     mean_ = mean1;
     covariance_ = cov1;
     eigenvectors_ = eigenvectors1;

--- a/src/MeshObject/Surface.cpp
+++ b/src/MeshObject/Surface.cpp
@@ -1009,8 +1009,7 @@ void Surface::add_point_to_surface_fitting(const Eigen::Vector3d& position, cons
     // point
     int size2 = 1;
     Eigen::Vector3d mean2 = position;
-    Eigen::Vector3d direction2 = (position - origin).normalized();
-    Eigen::Matrix3d cov2 = generate_directional_covariance(direction2, projection_uncertainty, 1e-6);
+    Eigen::Matrix3d cov2 = Eigen::Matrix3d::Zero();
 
     // set + point
     Eigen::Vector3d new_mean = merge_mean(mean1, mean2, size1, size2);
@@ -1083,8 +1082,7 @@ void Surface::remove_point_from_surface_fitting(const Eigen::Vector3d& position,
     // point
     int size2 = 1;
     Eigen::Vector3d mean2 = position;
-    Eigen::Vector3d direction2 = (position - origin).normalized();
-    Eigen::Matrix3d cov2 = generate_directional_covariance(direction2, projection_uncertainty, 1e-6);
+    Eigen::Matrix3d cov2 = Eigen::Matrix3d::Zero();
 
     // set + point
     Eigen::Vector3d mean1 = remove_mean(combined_mean, mean2, combined_size, size2);

--- a/src/MeshObject/Surface.cpp
+++ b/src/MeshObject/Surface.cpp
@@ -612,9 +612,20 @@ void Surface::connect(const std::shared_ptr<Vertex>& vertex)
     if (vertices_.insert(vertex).second)
     {
         vertex->connect(shared_from_this());
-        double projection_uncertainty = settings_.range_precision;
-        double weight = 1.0 / (projection_uncertainty * projection_uncertainty);
-        add_point_to_surface_fitting(vertex->get_position(), vertex->get_origin(), vertex->get_distance_travelled(), weight);
+
+        // update uncertainty
+        if (get_total_point_size() <= settings_.fit_plane_threshold) 
+        {
+            vertex->weight_ = 1.0 / (settings_.range_precision * settings_.range_precision);
+        }
+        else
+        {
+            // within the check relative position, the uncertainty will be updated
+            if (check_relative_position(vertex) != RelativePosition::WITHIN) throw std::runtime_error("Vertex is not within the surface.");
+            vertex->weight_ = 1.0 / (vertex->get_projected_uncertainty() * vertex->get_projected_uncertainty());
+        }
+
+        add_point_to_surface_fitting(vertex->get_position(), vertex->get_origin(), vertex->get_distance_travelled(), vertex->weight_);
     }
 }
 
@@ -889,9 +900,20 @@ void Surface::connect(const std::shared_ptr<InteriorPoint>& interior_point)
     // update surface fitting
     if (inserted) 
     {
-        double projection_uncertainty = settings_.range_precision;
-        double weight = 1.0 / (projection_uncertainty * projection_uncertainty);
-        add_point_to_surface_fitting(interior_point->get_position(), interior_point->get_origin(), interior_point->get_distance_travelled(), weight);
+
+        // update uncertainty
+        if (get_total_point_size() <= settings_.fit_plane_threshold) 
+        {
+            interior_point->weight_ = 1.0 / (settings_.range_precision * settings_.range_precision);
+        }
+        else
+        {
+            // within the check relative position, the uncertainty will be updated
+            if (check_relative_position(interior_point) != RelativePosition::WITHIN) throw std::runtime_error("Vertex is not within the surface.");
+            interior_point->weight_ = 1.0 / (interior_point->get_projected_uncertainty() * interior_point->get_projected_uncertainty());
+        }
+
+        add_point_to_surface_fitting(interior_point->get_position(), interior_point->get_origin(), interior_point->get_distance_travelled(), interior_point->weight_);
     }
 }
 
@@ -907,9 +929,9 @@ void Surface::disconnect(const std::shared_ptr<Vertex>& vertex)
     // remove from surface fitting
     if (erased) 
     {
-        double projection_uncertainty = settings_.range_precision;
-        double weight = 1.0 / (projection_uncertainty * projection_uncertainty);
-        remove_point_from_surface_fitting(vertex->get_position(), vertex->get_origin(), vertex->get_distance_travelled(), weight);
+        std::cout << "projective uncertainty of vertex: " << vertex->weight_ << std::endl;
+
+        remove_point_from_surface_fitting(vertex->get_position(), vertex->get_origin(), vertex->get_distance_travelled(), vertex->weight_);
     }
 }
 
@@ -945,9 +967,9 @@ void Surface::disconnect(const std::shared_ptr<InteriorPoint>& interior_point)
     // remove from surface fitting
     if (erased) 
     {
-        double projection_uncertainty = settings_.range_precision;
-        double weight = 1.0 / (projection_uncertainty * projection_uncertainty);
-        remove_point_from_surface_fitting(interior_point->get_position(), interior_point->get_origin(), interior_point->get_distance_travelled(), weight);
+        std::cout << "weight of interior_point: " << interior_point->weight_ << std::endl;
+
+        remove_point_from_surface_fitting(interior_point->get_position(), interior_point->get_origin(), interior_point->get_distance_travelled(), interior_point->weight_);
     }
 }
 

--- a/src/MeshObject/Surface.cpp
+++ b/src/MeshObject/Surface.cpp
@@ -929,7 +929,6 @@ void Surface::disconnect(const std::shared_ptr<Vertex>& vertex)
     // remove from surface fitting
     if (erased) 
     {
-        std::cout << "projective uncertainty of vertex: " << vertex->weight_ << std::endl;
 
         remove_point_from_surface_fitting(vertex->get_position(), vertex->get_origin(), vertex->get_distance_travelled(), vertex->weight_);
     }
@@ -967,7 +966,6 @@ void Surface::disconnect(const std::shared_ptr<InteriorPoint>& interior_point)
     // remove from surface fitting
     if (erased) 
     {
-        std::cout << "weight of interior_point: " << interior_point->weight_ << std::endl;
 
         remove_point_from_surface_fitting(interior_point->get_position(), interior_point->get_origin(), interior_point->get_distance_travelled(), interior_point->weight_);
     }

--- a/src/MeshObject/Surface.cpp
+++ b/src/MeshObject/Surface.cpp
@@ -613,7 +613,8 @@ void Surface::connect(const std::shared_ptr<Vertex>& vertex)
     {
         vertex->connect(shared_from_this());
         double projection_uncertainty = settings_.range_precision;
-        add_point_to_surface_fitting(vertex->get_position(), vertex->get_origin(), vertex->get_distance_travelled(), projection_uncertainty);
+        double weight = 1.0 / (projection_uncertainty * projection_uncertainty);
+        add_point_to_surface_fitting(vertex->get_position(), vertex->get_origin(), vertex->get_distance_travelled(), weight);
     }
 }
 
@@ -889,7 +890,8 @@ void Surface::connect(const std::shared_ptr<InteriorPoint>& interior_point)
     if (inserted) 
     {
         double projection_uncertainty = settings_.range_precision;
-        add_point_to_surface_fitting(interior_point->get_position(), interior_point->get_origin(), interior_point->get_distance_travelled(), projection_uncertainty);
+        double weight = 1.0 / (projection_uncertainty * projection_uncertainty);
+        add_point_to_surface_fitting(interior_point->get_position(), interior_point->get_origin(), interior_point->get_distance_travelled(), weight);
     }
 }
 
@@ -906,7 +908,8 @@ void Surface::disconnect(const std::shared_ptr<Vertex>& vertex)
     if (erased) 
     {
         double projection_uncertainty = settings_.range_precision;
-        remove_point_from_surface_fitting(vertex->get_position(), vertex->get_origin(), vertex->get_distance_travelled(), projection_uncertainty);
+        double weight = 1.0 / (projection_uncertainty * projection_uncertainty);
+        remove_point_from_surface_fitting(vertex->get_position(), vertex->get_origin(), vertex->get_distance_travelled(), weight);
     }
 }
 
@@ -943,7 +946,8 @@ void Surface::disconnect(const std::shared_ptr<InteriorPoint>& interior_point)
     if (erased) 
     {
         double projection_uncertainty = settings_.range_precision;
-        remove_point_from_surface_fitting(interior_point->get_position(), interior_point->get_origin(), interior_point->get_distance_travelled(), projection_uncertainty);
+        double weight = 1.0 / (projection_uncertainty * projection_uncertainty);
+        remove_point_from_surface_fitting(interior_point->get_position(), interior_point->get_origin(), interior_point->get_distance_travelled(), weight);
     }
 }
 
@@ -999,22 +1003,22 @@ void Surface::print_info()
     std::cout << "======================================================================================" << std::endl;
 }
 
-void Surface::add_point_to_surface_fitting(const Eigen::Vector3d& position, const Eigen::Vector3d& origin, double distance_travelled, double projection_uncertainty)
+void Surface::add_point_to_surface_fitting(const Eigen::Vector3d& position, const Eigen::Vector3d& origin, double distance_travelled, double weight)
 {
     // surface
-    int size1 = size_;
+    double weight1 = weight_;
     Eigen::Vector3d mean1 = mean_;
     Eigen::Matrix3d cov1 = covariance_;
 
     // point
-    int size2 = 1;
+    double weight2 = weight;
     Eigen::Vector3d mean2 = position;
     Eigen::Matrix3d cov2 = Eigen::Matrix3d::Zero();
 
     // set + point
-    Eigen::Vector3d new_mean = merge_mean(mean1, mean2, size1, size2);
-    Eigen::Matrix3d new_cov = merge_covariance(cov1, cov2, mean1, mean2, size1, size2);
-    int new_size = size1 + size2;
+    Eigen::Vector3d new_mean = weighted_merge_mean(mean1, mean2, weight1, weight2);
+    Eigen::Matrix3d new_cov = weighted_merge_covariance(cov1, cov2, mean1, mean2, weight1, weight2);
+    double new_weight = weight1 + weight2;
 
     // plane estimate
     Eigen::SelfAdjointEigenSolver<Eigen::Matrix3d> solver(new_cov);
@@ -1025,7 +1029,7 @@ void Surface::add_point_to_surface_fitting(const Eigen::Vector3d& position, cons
     if (new_normal.dot(vector_towards_origin) < 0) new_normal *= -1; // normal should points towards the origin
 
     // store
-    size_ = new_size;
+    weight_ = new_weight;
     mean_ = new_mean;
     covariance_ = new_cov;
     eigenvectors_ = new_eigenvectors;
@@ -1074,22 +1078,22 @@ void Surface::add_point_to_surface_fitting(const Eigen::Vector3d& position, cons
     }
 }
 
-void Surface::remove_point_from_surface_fitting(const Eigen::Vector3d& position, const Eigen::Vector3d& origin, double distance_travelled, double projection_uncertainty)
+void Surface::remove_point_from_surface_fitting(const Eigen::Vector3d& position, const Eigen::Vector3d& origin, double distance_travelled, double weight)
 {
     // surface
-    int combined_size = size_;
+    double combined_weight = weight_;
     Eigen::Vector3d combined_mean = mean_;
     Eigen::Matrix3d combined_cov = covariance_;
 
     // point
-    int size2 = 1;
+    double weight2 = weight;
     Eigen::Vector3d mean2 = position;
     Eigen::Matrix3d cov2 = Eigen::Matrix3d::Zero();
 
     // set + point
-    Eigen::Vector3d mean1 = remove_mean(combined_mean, mean2, combined_size, size2);
-    Eigen::Matrix3d cov1 = remove_covariance(combined_cov, cov2, combined_mean, mean2, combined_size, size2);
-    int size1 = combined_size - size2;
+    Eigen::Vector3d mean1 = remove_mean(combined_mean, mean2, combined_weight, weight2);
+    Eigen::Matrix3d cov1 = remove_covariance(combined_cov, cov2, combined_mean, mean2, combined_weight, weight2);
+    double weight1 = combined_weight - weight2;
 
     // plane estimate
     Eigen::SelfAdjointEigenSolver<Eigen::Matrix3d> solver(cov1);
@@ -1100,7 +1104,7 @@ void Surface::remove_point_from_surface_fitting(const Eigen::Vector3d& position,
     if (normal1.dot(vector_towards_origin) < 0) normal1 *= -1; // normal should points towards the origin
 
     // store
-    size_ = size1;
+    weight_ = weight1;
     mean_ = mean1;
     covariance_ = cov1;
     eigenvectors_ = eigenvectors1;

--- a/src/MeshObject/Surface.cpp
+++ b/src/MeshObject/Surface.cpp
@@ -612,7 +612,8 @@ void Surface::connect(const std::shared_ptr<Vertex>& vertex)
     if (vertices_.insert(vertex).second)
     {
         vertex->connect(shared_from_this());
-        add_point_to_surface_fitting(vertex->get_position(), vertex->get_origin(), vertex->get_distance_travelled());
+        double projection_uncertainty = settings_.range_precision;
+        add_point_to_surface_fitting(vertex->get_position(), vertex->get_origin(), vertex->get_distance_travelled(), projection_uncertainty);
     }
 }
 
@@ -885,7 +886,11 @@ void Surface::connect(const std::shared_ptr<InteriorPoint>& interior_point)
     if (inserted) interior_point->connect(shared_from_this());
 
     // update surface fitting
-    if (inserted) add_point_to_surface_fitting(interior_point->get_position(), interior_point->get_origin(), interior_point->get_distance_travelled());
+    if (inserted) 
+    {
+        double projection_uncertainty = settings_.range_precision;
+        add_point_to_surface_fitting(interior_point->get_position(), interior_point->get_origin(), interior_point->get_distance_travelled(), projection_uncertainty);
+    }
 }
 
 void Surface::disconnect(const std::shared_ptr<Vertex>& vertex)
@@ -898,7 +903,11 @@ void Surface::disconnect(const std::shared_ptr<Vertex>& vertex)
     if (erased) vertex->disconnect(shared_from_this());
 
     // remove from surface fitting
-    if (erased) remove_point_from_surface_fitting(vertex->get_position(), vertex->get_origin(), vertex->get_distance_travelled());
+    if (erased) 
+    {
+        double projection_uncertainty = settings_.range_precision;
+        remove_point_from_surface_fitting(vertex->get_position(), vertex->get_origin(), vertex->get_distance_travelled(), projection_uncertainty);
+    }
 }
 
 void Surface::disconnect(const std::shared_ptr<Edge>& edge)
@@ -931,7 +940,11 @@ void Surface::disconnect(const std::shared_ptr<InteriorPoint>& interior_point)
     if (erased) interior_point->disconnect(shared_from_this());
 
     // remove from surface fitting
-    if (erased) remove_point_from_surface_fitting(interior_point->get_position(), interior_point->get_origin(), interior_point->get_distance_travelled());
+    if (erased) 
+    {
+        double projection_uncertainty = settings_.range_precision;
+        remove_point_from_surface_fitting(interior_point->get_position(), interior_point->get_origin(), interior_point->get_distance_travelled(), projection_uncertainty);
+    }
 }
 
 void Surface::swap(const std::shared_ptr<Vertex>& vertex1, const std::shared_ptr<Vertex>& vertex2)
@@ -986,7 +999,7 @@ void Surface::print_info()
     std::cout << "======================================================================================" << std::endl;
 }
 
-void Surface::add_point_to_surface_fitting(const Eigen::Vector3d& position, const Eigen::Vector3d& origin, double distance_travelled)
+void Surface::add_point_to_surface_fitting(const Eigen::Vector3d& position, const Eigen::Vector3d& origin, double distance_travelled, double projection_uncertainty)
 {
     // surface
     int size1 = get_total_point_size()-1; // need to exclude the new point
@@ -996,7 +1009,7 @@ void Surface::add_point_to_surface_fitting(const Eigen::Vector3d& position, cons
     // point
     int size2 = 1;
     Eigen::Vector3d mean2 = position;
-    Eigen::Matrix3d cov2 = Eigen::Matrix3d::Zero();
+    Eigen::Matrix3d cov2 = Eigen::Matrix3d::Identity() * std::pow(projection_uncertainty, 2);
 
     // set + point
     Eigen::Vector3d new_mean = merge_mean(mean1, mean2, size1, size2);
@@ -1059,7 +1072,7 @@ void Surface::add_point_to_surface_fitting(const Eigen::Vector3d& position, cons
     }
 }
 
-void Surface::remove_point_from_surface_fitting(const Eigen::Vector3d& position, const Eigen::Vector3d& origin, double distance_travelled)
+void Surface::remove_point_from_surface_fitting(const Eigen::Vector3d& position, const Eigen::Vector3d& origin, double distance_travelled, double projection_uncertainty)
 {
     // surface
     int combined_size = get_total_point_size()+1; // need to include the point just removed
@@ -1069,7 +1082,7 @@ void Surface::remove_point_from_surface_fitting(const Eigen::Vector3d& position,
     // point
     int size2 = 1;
     Eigen::Vector3d mean2 = position;
-    Eigen::Matrix3d cov2 = Eigen::Matrix3d::Zero();
+    Eigen::Matrix3d cov2 = Eigen::Matrix3d::Identity() * std::pow(projection_uncertainty, 2);
 
     // set + point
     Eigen::Vector3d mean1 = remove_mean(combined_mean, mean2, combined_size, size2);

--- a/src/MeshObject/Surface.cpp
+++ b/src/MeshObject/Surface.cpp
@@ -1091,8 +1091,8 @@ void Surface::remove_point_from_surface_fitting(const Eigen::Vector3d& position,
     Eigen::Matrix3d cov2 = Eigen::Matrix3d::Zero();
 
     // set + point
-    Eigen::Vector3d mean1 = remove_mean(combined_mean, mean2, combined_weight, weight2);
-    Eigen::Matrix3d cov1 = remove_covariance(combined_cov, cov2, combined_mean, mean2, combined_weight, weight2);
+    Eigen::Vector3d mean1 = weighted_remove_mean(combined_mean, mean2, combined_weight, weight2);
+    Eigen::Matrix3d cov1 = weighted_remove_covariance(combined_cov, cov2, combined_mean, mean2, combined_weight, weight2);
     double weight1 = combined_weight - weight2;
 
     // plane estimate

--- a/src/MeshObject/Surface.cpp
+++ b/src/MeshObject/Surface.cpp
@@ -188,14 +188,14 @@ RelativePosition Surface::check_relative_position(double distance_travelled, con
         double variance_range_direction = d_range_d_direction.transpose() * cov_direction * d_range_d_direction;
         double variance_range_normal = d_range_d_normal.transpose() * cov_normal * d_range_d_normal;
 
-        // compute std of range due to ...
-        double std_range_origin = std::sqrt(variance_range_origin);
-        double std_range_mean = std::sqrt(variance_range_mean);
-        double std_range_direction = std::sqrt(variance_range_direction);
-        double std_range_normal = std::sqrt(variance_range_normal);
+        // // compute std of range due to ...
+        // double std_range_origin = std::sqrt(variance_range_origin);
+        // double std_range_mean = std::sqrt(variance_range_mean);
+        // double std_range_direction = std::sqrt(variance_range_direction);
+        // double std_range_normal = std::sqrt(variance_range_normal);
 
         // compute combined std
-        double combined_std = std::sqrt(std_range_origin * std_range_origin + std_range_mean * std_range_mean + std_range_direction * std_range_direction + std_range_normal * std_range_normal + settings_.range_precision * settings_.range_precision);
+        double combined_std = std::sqrt(variance_range_origin + variance_range_mean + variance_range_direction + variance_range_normal + settings_.range_precision * settings_.range_precision);
 
         // compute point to plane projective distance
         double projective_distance = compute_point_projective_distance(origin, point);

--- a/src/MeshObject/Surface.cpp
+++ b/src/MeshObject/Surface.cpp
@@ -1009,7 +1009,8 @@ void Surface::add_point_to_surface_fitting(const Eigen::Vector3d& position, cons
     // point
     int size2 = 1;
     Eigen::Vector3d mean2 = position;
-    Eigen::Matrix3d cov2 = Eigen::Matrix3d::Identity() * std::pow(projection_uncertainty, 2);
+    Eigen::Vector3d direction2 = (position - origin).normalized();
+    Eigen::Matrix3d cov2 = generate_directional_covariance(direction2, projection_uncertainty, 1e-6);
 
     // set + point
     Eigen::Vector3d new_mean = merge_mean(mean1, mean2, size1, size2);
@@ -1082,7 +1083,8 @@ void Surface::remove_point_from_surface_fitting(const Eigen::Vector3d& position,
     // point
     int size2 = 1;
     Eigen::Vector3d mean2 = position;
-    Eigen::Matrix3d cov2 = Eigen::Matrix3d::Identity() * std::pow(projection_uncertainty, 2);
+    Eigen::Vector3d direction2 = (position - origin).normalized();
+    Eigen::Matrix3d cov2 = generate_directional_covariance(direction2, projection_uncertainty, 1e-6);
 
     // set + point
     Eigen::Vector3d mean1 = remove_mean(combined_mean, mean2, combined_size, size2);

--- a/src/utilities/covariance_math.cpp
+++ b/src/utilities/covariance_math.cpp
@@ -81,9 +81,11 @@ Eigen::Matrix3d weighted_merge_covariance(const Eigen::Matrix3d& cov1, const Eig
 // weighted remove mean2 from combined_mean
 Eigen::Vector3d weighted_remove_mean(const Eigen::Vector3d& combined_mean, const Eigen::Vector3d& mean2, double combined_weight, double weight2) 
 {
-    if (combined_weight < weight2) throw std::invalid_argument("Size of the combined_mean must be greater than size of mean2");
+    double epsilon = 1e-6;
+
+    if (combined_weight - weight2 < -epsilon) throw std::invalid_argument("Size of the combined_weight " + std::to_string(combined_weight) + " must be greater than size of weight2 " + std::to_string(weight2));
     double weight1 = combined_weight - weight2;
-    if (weight1 == 0) return Eigen::Vector3d::Zero();
+    if (std::abs(weight1) < epsilon) return Eigen::Vector3d::Zero();
     
     return (combined_weight * combined_mean - weight2 * mean2) / weight1;
 }
@@ -93,9 +95,11 @@ Eigen::Matrix3d weighted_remove_covariance(const Eigen::Matrix3d& combined_covar
                                 const Eigen::Vector3d& combined_mean, const Eigen::Vector3d& mean2, 
                                 double combined_weight, double weight2) 
 {
-    if (combined_weight < weight2) throw std::invalid_argument("Size of the combined_cov must be greater than size of the cov2");
+    double epsilon = 1e-6;
+
+    if (combined_weight - weight2 < -epsilon) throw std::invalid_argument("Size of the combined_weight " + std::to_string(combined_weight) + " must be greater than size of weight2 " + std::to_string(weight2));
     double weight1 = combined_weight - weight2;
-    if (weight1 == 0) return Eigen::Matrix3d::Zero();
+    if (std::abs(weight1) < epsilon) return Eigen::Matrix3d::Zero();
 
     Eigen::Vector3d mean1 = remove_mean(combined_mean, mean2, combined_weight, weight2);
 

--- a/src/utilities/covariance_math.cpp
+++ b/src/utilities/covariance_math.cpp
@@ -70,7 +70,7 @@ Eigen::Matrix3d weighted_merge_covariance(const Eigen::Matrix3d& cov1, const Eig
     if (weight1 == 0) return cov2;
     if (weight2 == 0) return cov1;
 
-    Eigen::Vector3d combined_mean = merge_mean(mean1, mean2, weight1, weight2);
+    Eigen::Vector3d combined_mean = weighted_merge_mean(mean1, mean2, weight1, weight2);
     Eigen::Matrix3d mean_diff1 = (mean1 - combined_mean) * (mean1 - combined_mean).transpose();
     Eigen::Matrix3d mean_diff2 = (mean2 - combined_mean) * (mean2 - combined_mean).transpose();
     Eigen::Matrix3d combined_covariance = (weight1 * cov1 + weight2 * cov2 + weight1 * mean_diff1 + weight2 * mean_diff2) / (weight1 + weight2);
@@ -101,7 +101,7 @@ Eigen::Matrix3d weighted_remove_covariance(const Eigen::Matrix3d& combined_covar
     double weight1 = combined_weight - weight2;
     if (std::abs(weight1) < epsilon) return Eigen::Matrix3d::Zero();
 
-    Eigen::Vector3d mean1 = remove_mean(combined_mean, mean2, combined_weight, weight2);
+    Eigen::Vector3d mean1 = weighted_remove_mean(combined_mean, mean2, combined_weight, weight2);
 
     Eigen::Matrix3d mean_diff1 = (mean1 - combined_mean) * (mean1 - combined_mean).transpose();
     Eigen::Matrix3d mean_diff2 = (mean2 - combined_mean) * (mean2 - combined_mean).transpose();

--- a/src/utilities/covariance_math.cpp
+++ b/src/utilities/covariance_math.cpp
@@ -53,6 +53,59 @@ Eigen::Matrix3d remove_covariance(const Eigen::Matrix3d& combined_covariance, co
     return cov1;
 }
 
+
+// weighted add mean2 to mean1
+Eigen::Vector3d weighted_merge_mean(const Eigen::Vector3d& mean1, const Eigen::Vector3d& mean2, double weight1, double weight2) 
+{
+    return (weight1 * mean1 + weight2 * mean2) / (weight1 + weight2);
+}
+
+// weighted add cov2 to cov1
+Eigen::Matrix3d weighted_merge_covariance(const Eigen::Matrix3d& cov1, const Eigen::Matrix3d& cov2, 
+                                const Eigen::Vector3d& mean1, const Eigen::Vector3d& mean2, 
+                                double weight1, double weight2) 
+{
+    // Handle the edge case where one of the sizes is zero
+    if (weight1 == 0 && weight2 == 0) throw std::invalid_argument("Both sizes are zero");
+    if (weight1 == 0) return cov2;
+    if (weight2 == 0) return cov1;
+
+    Eigen::Vector3d combined_mean = merge_mean(mean1, mean2, weight1, weight2);
+    Eigen::Matrix3d mean_diff1 = (mean1 - combined_mean) * (mean1 - combined_mean).transpose();
+    Eigen::Matrix3d mean_diff2 = (mean2 - combined_mean) * (mean2 - combined_mean).transpose();
+    Eigen::Matrix3d combined_covariance = (weight1 * cov1 + weight2 * cov2 + weight1 * mean_diff1 + weight2 * mean_diff2) / (weight1 + weight2);
+
+    return combined_covariance;
+}
+
+// weighted remove mean2 from combined_mean
+Eigen::Vector3d weighted_remove_mean(const Eigen::Vector3d& combined_mean, const Eigen::Vector3d& mean2, double combined_weight, double weight2) 
+{
+    if (combined_weight < weight2) throw std::invalid_argument("Size of the combined_mean must be greater than size of mean2");
+    double weight1 = combined_weight - weight2;
+    if (weight1 == 0) return Eigen::Vector3d::Zero();
+    
+    return (combined_weight * combined_mean - weight2 * mean2) / weight1;
+}
+
+// weighted remove cov2 from combined_covariance
+Eigen::Matrix3d weighted_remove_covariance(const Eigen::Matrix3d& combined_covariance, const Eigen::Matrix3d& cov2, 
+                                const Eigen::Vector3d& combined_mean, const Eigen::Vector3d& mean2, 
+                                double combined_weight, double weight2) 
+{
+    if (combined_weight < weight2) throw std::invalid_argument("Size of the combined_cov must be greater than size of the cov2");
+    double weight1 = combined_weight - weight2;
+    if (weight1 == 0) return Eigen::Matrix3d::Zero();
+
+    Eigen::Vector3d mean1 = remove_mean(combined_mean, mean2, combined_weight, weight2);
+
+    Eigen::Matrix3d mean_diff1 = (mean1 - combined_mean) * (mean1 - combined_mean).transpose();
+    Eigen::Matrix3d mean_diff2 = (mean2 - combined_mean) * (mean2 - combined_mean).transpose();
+    Eigen::Matrix3d cov1 = (combined_covariance * combined_weight - weight2 * cov2 - weight1 * mean_diff1 - weight2 * mean_diff2) / weight1;
+
+    return cov1;
+}
+
 double merge_information_weighted_mean(const double& mean1, const double& mean2, const double& information1, const double& information2) 
 {
     return (information1 * mean1 + information2 * mean2) / (information1 + information2);

--- a/src/utilities/utilities.cpp
+++ b/src/utilities/utilities.cpp
@@ -103,6 +103,10 @@ Eigen::Matrix3d generate_unit_vector_covariance(const Eigen::Vector3d& unit_vect
     return basis * cov * basis.transpose();
 }
 
+Eigen::Matrix3d generate_directional_covariance(const Eigen::Vector3d& direction_vector, double uncertainty_in_direction, double epsilon)
+{
+    return generate_unit_vector_covariance(direction_vector, epsilon, uncertainty_in_direction);
+}
 
 double shortest_distance_to_line_segment(const Eigen::Vector3d& rayOrigin, const Eigen::Vector3d& rayEnd, const Eigen::Vector3d& targetPoint) 
 {


### PR DESCRIPTION
### what I've done
- **covariance math**
  - change the covariance merging from **size** weighted into **weight** weighted
- **extract weight** 
  - weight = 1/variance of point computed relative to the plane
- **numerical stability**
  - improve numerical stability in computing combined_std
- **color display**
  - add weight colour display

### result 
- ![Screenshot from 2024-12-13 10-31-51](https://github.com/user-attachments/assets/f626d984-e98d-4a83-943f-023e6f958634)

### more detials
- https://github.com/ori-drs/eye_patch/issues/31#issuecomment-2541154667
