### PR TITLE
22 improve mesh expansion

### DIFF
--- a/include/MeshObject/InteriorPoint.hpp
+++ b/include/MeshObject/InteriorPoint.hpp
@@ -25,6 +25,7 @@ protected:
 
 public:
     const int& get_id() const;
+    const Eigen::Vector3d& get_original_position() const;
     const Eigen::Vector3d& get_position() const;
     const Eigen::Vector3d& get_origin() const;
     const double& get_distance_travelled() const;
@@ -92,6 +93,8 @@ private:
 
     FIFOCache<std::size_t, Eigen::Vector3d> buffer_projected_position_{3};
     FIFOCache<std::size_t, double> buffer_projected_distance_{3};
+
+    Eigen::Vector3d projected_position_ = Eigen::Vector3d::Zero();
 
 public:
     double weight_;

--- a/include/MeshObject/Vertex.hpp
+++ b/include/MeshObject/Vertex.hpp
@@ -36,6 +36,7 @@ public:
     std::shared_ptr<RRSNode> node;
 
     const int& get_id() const;
+    const Eigen::Vector3d& get_original_position() const;
     const Eigen::Vector3d& get_position() const;
     const Eigen::Vector3d& get_origin() const;
     const double& get_distance_travelled() const;
@@ -154,6 +155,8 @@ private:
     Eigen::Vector3d direction_;
 
     double projected_uncertainty_;
+
+    Eigen::Vector3d projected_position_ = Eigen::Vector3d::Zero();
 
 public:
     double weight_;

--- a/src/MeshObject/Application.cpp
+++ b/src/MeshObject/Application.cpp
@@ -411,6 +411,7 @@ bool Application<PointT>::add_point_by_intersection_search(const std::shared_ptr
         if (surface->get_total_point_size() < settings_.fit_plane_threshold)
         {
             surfaces_seed.insert(surface);
+            continue;
         }
 
         // relative position

--- a/src/MeshObject/Application.cpp
+++ b/src/MeshObject/Application.cpp
@@ -361,6 +361,10 @@ void Application<PointT>::process_point(const std::shared_ptr<GenericPoint>& gen
 
     num_of_concurrent_processes--;
     
+    // after unlocking all locks, add the point in queue to the search tree
+    storage_->add_points_in_affected_vertices_set();
+    storage_->add_faces_in_affected_faces_set();
+
     //
     // they all lead to return, thus unlock all locks
     //
@@ -375,10 +379,6 @@ void Application<PointT>::process_point(const std::shared_ptr<GenericPoint>& gen
     for (const std::shared_ptr<RRSNode>& node : locked_rrs_nodes) node->recursive_unlock();
 
     // lock.unlock();
-
-    // after unlocking all locks, add the point in queue to the search tree
-    storage_->add_points_in_affected_vertices_set();
-    storage_->add_faces_in_affected_faces_set();
 }
 
 template <typename PointT>

--- a/src/MeshObject/Application.cpp
+++ b/src/MeshObject/Application.cpp
@@ -642,7 +642,18 @@ bool Application<PointT>::add_point_by_radius_search(const std::shared_ptr<Gener
     std::shared_ptr<Vertex> new_vertex = storage_->add_vertex(surface_to_add_to, generic_point);
     new_vertex->reduce_reverse_radius_search_radius(new_point_radius);
     new_vertex->reduce_previous_radius(new_point_radius);
-    surface_to_add_to->connect_by_edges_and_faces(new_vertex, all_vertices);
+    const bool connected = surface_to_add_to->connect_by_edges_and_faces(new_vertex, all_vertices);
+    
+    // there are singular points of a surface that are not connected to any other points
+    // perhaps this is the cause.
+    // if not connected, delete this point 
+    if (!connected)
+    {
+        storage_->delete_vertex(new_vertex);
+        return false;
+    }
+
+    // else
     return true;
 }
 

--- a/src/MeshObject/Edge.cpp
+++ b/src/MeshObject/Edge.cpp
@@ -355,13 +355,13 @@ void Edge::update_searchable_state()
     // add
     if (is_boundary_ && !is_searchable_)
     {
-        surface_->add_searchable_edge(shared_from_this());
+        // surface_->add_searchable_edge(shared_from_this());
         is_searchable_ = true;
     }
     // remove
     if (!is_boundary_ && is_searchable_)
     {   
-        surface_->remove_searchable_edge(shared_from_this());
+        // surface_->remove_searchable_edge(shared_from_this());
         is_searchable_ = false;
     }
 }
@@ -370,7 +370,7 @@ void Edge::remove_searchable_state()
 {
     if (is_searchable_)
     {
-        surface_->remove_searchable_edge(shared_from_this());
+        // surface_->remove_searchable_edge(shared_from_this());
         is_searchable_ = false;
     }
 }

--- a/src/MeshObject/GenericPoint.cpp
+++ b/src/MeshObject/GenericPoint.cpp
@@ -42,7 +42,7 @@ void GenericPoint::initialize_(const std::shared_ptr<Storage>& storage, const Ei
 
 void GenericPoint::initialize_(const std::shared_ptr<Storage>& storage, const std::shared_ptr<Vertex>& vertex)
 {
-    initialize_(storage, vertex->get_position(), vertex->get_origin(), vertex->get_distance_travelled());
+    initialize_(storage, vertex->get_original_position(), vertex->get_origin(), vertex->get_distance_travelled());
     previous_surface_ = vertex->get_surface();
     previous_radius_ = vertex->get_radius();
 
@@ -51,7 +51,7 @@ void GenericPoint::initialize_(const std::shared_ptr<Storage>& storage, const st
 
 void GenericPoint::initialize_(const std::shared_ptr<Storage>& storage, const std::shared_ptr<InteriorPoint>& interior_point)
 {
-    initialize_(storage, interior_point->get_position(), interior_point->get_origin(), interior_point->get_distance_travelled());
+    initialize_(storage, interior_point->get_original_position(), interior_point->get_origin(), interior_point->get_distance_travelled());
     previous_surface_ = interior_point->get_surface();
     previous_radius_ = interior_point->get_radius();
 

--- a/src/MeshObject/InteriorPoint.cpp
+++ b/src/MeshObject/InteriorPoint.cpp
@@ -87,9 +87,17 @@ const int& InteriorPoint::get_id() const
     return id_;
 }
 
-const Eigen::Vector3d& InteriorPoint::get_position() const
+const Eigen::Vector3d& InteriorPoint::get_original_position() const
 {
     return position_;
+}
+
+const Eigen::Vector3d& InteriorPoint::get_position() const
+{
+    if (projected_position_.isZero()) throw std::runtime_error("Interior projected position is not set.");
+
+    return projected_position_;
+    // return position_;
 }
 
 const Eigen::Vector3d& InteriorPoint::get_origin() const
@@ -132,7 +140,7 @@ const Eigen::Vector3d& InteriorPoint::buffer_compute_projected_position(const st
     // add to cache if not exist
     if (!buffer_projected_position_.exists(hash)) 
     {
-        const Eigen::Vector3d computedResult = surface->compute_point_projective_position(get_origin(), get_position());
+        const Eigen::Vector3d computedResult = surface->compute_point_projective_position(get_origin(), get_original_position());
         buffer_projected_position_.put(hash, computedResult);
     }
 
@@ -150,7 +158,7 @@ const double& InteriorPoint::buffer_compute_projected_distance(const std::shared
     // add to cache if not exist
     if (!buffer_projected_distance_.exists(hash)) 
     {
-        const double computedResult = surface->compute_point_projective_distance(get_origin(), get_position());
+        const double computedResult = surface->compute_point_projective_distance(get_origin(), get_original_position());
         buffer_projected_distance_.put(hash, computedResult);
     }
 
@@ -208,6 +216,9 @@ void InteriorPoint::connect(const std::shared_ptr<Surface>& surface)
     if (inserted) surface_ = surface;
     if (inserted) 
     {
+        // update projected position
+        projected_position_ = surface->compute_point_projective_position(get_origin(), get_original_position());
+
         // if new surface is the same as the previous surface, set the radius to the updated previous radius
         if (surface == previous_surface_) 
         {
@@ -266,6 +277,7 @@ void InteriorPoint::disconnect(const std::shared_ptr<Surface>& surface)
     bool erased = surface_ == surface;
     if (erased) surface->disconnect(shared_from_this());
     if (erased) surface_ = nullptr;
+    if (erased) projected_position_ = Eigen::Vector3d::Zero();
 
     // self destruct
     if (!deleting_ && erased && can_self_destruct_) storage_->delete_interior_point(shared_from_this());

--- a/src/MeshObject/Storage.cpp
+++ b/src/MeshObject/Storage.cpp
@@ -679,6 +679,9 @@ void Storage::add_faces_in_affected_faces_set()
 {
     for (const std::shared_ptr<Face>& face : smaller_affected_faces_sets_[omp_get_thread_num()])
     {
+        // skip if face is expired, but really there should not have been any expired face in the set
+        if (face->is_expired()) continue;
+
         // i need a explicit flag that indicates if the vertex is added to the rrs tree or not, instead of just a is_searchable flag
 
         // check if vertex needs to be added or removed or unchanged from rrs_tree

--- a/src/MeshObject/Storage.cpp
+++ b/src/MeshObject/Storage.cpp
@@ -651,6 +651,9 @@ void Storage::add_points_in_affected_vertices_set()
 {
     for (const std::shared_ptr<Vertex>& vertex : smaller_affected_vertices_sets_[omp_get_thread_num()])
     {
+        // skip if vertex is expired, but really we should reduce the number of expired vertex in the set
+        if (vertex->is_expired()) continue;
+
         // i need a explicit flag that indicates if the vertex is added to the rrs tree or not, instead of just a is_searchable flag
 
         // check if vertex needs to be added or removed or unchanged from rrs_tree

--- a/src/MeshObject/Surface.cpp
+++ b/src/MeshObject/Surface.cpp
@@ -89,6 +89,8 @@ const int& Surface::get_id() const
 
 double Surface::compute_point_to_plane_distance(const Eigen::Vector3d& point) const
 {
+    if (get_total_point_size() < settings_.fit_plane_threshold) throw std::runtime_error("Surface is seed surface.");
+
     return (point - mean_).dot(normal_);
 }
 
@@ -145,6 +147,9 @@ double Surface::compute_point_projective_distance_with_improved_covariance(const
 
 Eigen::Vector3d Surface::compute_point_projective_position(const Eigen::Vector3d& origin, const Eigen::Vector3d& point) const
 {
+    // if surface is seed surface, return original point as projected point
+    if (get_total_point_size() < settings_.fit_plane_threshold) return point;
+
     // compute
     Eigen::Vector3d rayDirection = (point - origin).normalized();
     double distance = (mean_ - point).dot(normal_) / rayDirection.dot(normal_);
@@ -294,7 +299,7 @@ RelativePosition Surface::check_relative_position(const std::shared_ptr<GenericP
 
 RelativePosition Surface::check_relative_position(const std::shared_ptr<Vertex>& vertex)
 {
-    return check_relative_position(vertex->get_distance_travelled(), vertex->get_origin(), vertex->get_position(), vertex->get_direction(), vertex->get_projected_uncertainty());
+    return check_relative_position(vertex->get_distance_travelled(), vertex->get_origin(), vertex->get_original_position(), vertex->get_direction(), vertex->get_projected_uncertainty());
 }
 
 // RelativePosition Surface::check_relative_position(const std::shared_ptr<Vertex>& vertex)
@@ -329,7 +334,7 @@ RelativePosition Surface::check_relative_position(const std::shared_ptr<Vertex>&
 
 RelativePosition Surface::check_relative_position(const std::shared_ptr<InteriorPoint>& interior_point)
 {
-    return check_relative_position(interior_point->get_distance_travelled(), interior_point->get_origin(), interior_point->get_position(), interior_point->get_direction(), interior_point->get_projected_uncertainty());
+    return check_relative_position(interior_point->get_distance_travelled(), interior_point->get_origin(), interior_point->get_original_position(), interior_point->get_direction(), interior_point->get_projected_uncertainty());
 }
 
 // RelativePosition Surface::check_relative_position(const std::shared_ptr<InteriorPoint>& interior_point)
@@ -457,12 +462,12 @@ const std::vector<double>& Surface::get_point_to_plane_distance_stats()
         // add
         for (const auto& vertex : vertices_)
         {
-            double point2plane_distance = (vertex->get_position() - get_mean()).dot(get_normal());
+            double point2plane_distance = (vertex->get_original_position() - get_mean()).dot(get_normal());
             stored_point_to_plane_distance_stats_.push_back(point2plane_distance);
         }
         for (const auto& interior_point : interior_points_)
         {
-            double point2plane_distance = (interior_point->get_position() - get_mean()).dot(get_normal());
+            double point2plane_distance = (interior_point->get_original_position() - get_mean()).dot(get_normal());
             stored_point_to_plane_distance_stats_.push_back(point2plane_distance);
         }
 
@@ -577,10 +582,10 @@ bool Surface::can_merge(const std::shared_ptr<Surface>& surface) const
 
     // compute projective distance stats for the combined surface
     std::vector<double> projective_distance_list;
-    for (const auto& vertex : vertices_)                            projective_distance_list.push_back((new_mean - vertex->get_position()).dot(new_normal) / vertex->get_direction().dot(new_normal));
-    for (const auto& interior_point : interior_points_)             projective_distance_list.push_back((new_mean - interior_point->get_position()).dot(new_normal) / interior_point->get_direction().dot(new_normal));
-    for (const auto& vertex : surface->vertices_)                   projective_distance_list.push_back((new_mean - vertex->get_position()).dot(new_normal) / vertex->get_direction().dot(new_normal));
-    for (const auto& interior_point : surface->interior_points_)    projective_distance_list.push_back((new_mean - interior_point->get_position()).dot(new_normal) / interior_point->get_direction().dot(new_normal));
+    for (const auto& vertex : vertices_)                            projective_distance_list.push_back((new_mean - vertex->get_original_position()).dot(new_normal) / vertex->get_direction().dot(new_normal));
+    for (const auto& interior_point : interior_points_)             projective_distance_list.push_back((new_mean - interior_point->get_original_position()).dot(new_normal) / interior_point->get_direction().dot(new_normal));
+    for (const auto& vertex : surface->vertices_)                   projective_distance_list.push_back((new_mean - vertex->get_original_position()).dot(new_normal) / vertex->get_direction().dot(new_normal));
+    for (const auto& interior_point : surface->interior_points_)    projective_distance_list.push_back((new_mean - interior_point->get_original_position()).dot(new_normal) / interior_point->get_direction().dot(new_normal));
 
     // subtract accuracy from each distance
     std::vector<double> projective_distance_list_modified = projective_distance_list;
@@ -625,7 +630,7 @@ void Surface::connect(const std::shared_ptr<Vertex>& vertex)
             vertex->weight_ = 1.0 / (vertex->get_projected_uncertainty() * vertex->get_projected_uncertainty());
         }
 
-        add_point_to_surface_fitting(vertex->get_position(), vertex->get_origin(), vertex->get_distance_travelled(), vertex->weight_);
+        add_point_to_surface_fitting(vertex->get_original_position(), vertex->get_origin(), vertex->get_distance_travelled(), vertex->weight_);
     }
 }
 
@@ -890,7 +895,7 @@ void Surface::connect(const std::shared_ptr<InteriorPoint>& interior_point)
             interior_point->weight_ = 1.0 / (interior_point->get_projected_uncertainty() * interior_point->get_projected_uncertainty());
         }
 
-        add_point_to_surface_fitting(interior_point->get_position(), interior_point->get_origin(), interior_point->get_distance_travelled(), interior_point->weight_);
+        add_point_to_surface_fitting(interior_point->get_original_position(), interior_point->get_origin(), interior_point->get_distance_travelled(), interior_point->weight_);
     }
 }
 
@@ -907,7 +912,7 @@ void Surface::disconnect(const std::shared_ptr<Vertex>& vertex)
     if (erased) 
     {
 
-        remove_point_from_surface_fitting(vertex->get_position(), vertex->get_origin(), vertex->get_distance_travelled(), vertex->weight_);
+        remove_point_from_surface_fitting(vertex->get_original_position(), vertex->get_origin(), vertex->get_distance_travelled(), vertex->weight_);
     }
 }
 
@@ -948,7 +953,7 @@ void Surface::disconnect(const std::shared_ptr<InteriorPoint>& interior_point)
     if (erased) 
     {
 
-        remove_point_from_surface_fitting(interior_point->get_position(), interior_point->get_origin(), interior_point->get_distance_travelled(), interior_point->weight_);
+        remove_point_from_surface_fitting(interior_point->get_original_position(), interior_point->get_origin(), interior_point->get_distance_travelled(), interior_point->weight_);
     }
 }
 
@@ -1177,11 +1182,11 @@ void Surface::optimize_surface_normal()
     std::vector<std::pair<Eigen::Vector3d, Eigen::Vector3d>> dataset;
     for (const auto& vertex : vertices_)
     {
-        dataset.push_back(std::make_pair(vertex->get_origin(), vertex->get_position()));
+        dataset.push_back(std::make_pair(vertex->get_origin(), vertex->get_original_position()));
     }
     for (const auto& interior_point : interior_points_)
     {
-        dataset.push_back(std::make_pair(interior_point->get_origin(), interior_point->get_position()));
+        dataset.push_back(std::make_pair(interior_point->get_origin(), interior_point->get_original_position()));
     }
 
     fit_plane_to_points(dataset, mean_, normal_, bearing_noise, range_noise);

--- a/src/MeshObject/Surface.cpp
+++ b/src/MeshObject/Surface.cpp
@@ -665,8 +665,6 @@ bool Surface::connect_by_edges_and_faces(const std::shared_ptr<Vertex>& vertex, 
     {
         // skip if edge is longer than any of the radius of vertices
         double distance = (vertex->get_position() - nearby_vertex->get_position()).norm();
-        
-        // skip if edge is longer than either vertices radius
         if (distance > vertex->get_radius(shared_from_this()) || distance > nearby_vertex->get_radius()) continue;
 
         // if edge intersects
@@ -688,23 +686,10 @@ bool Surface::connect_by_edges_and_faces(const std::shared_ptr<Vertex>& vertex, 
             // create edge
             std::shared_ptr<Edge> new_edge = storage_->add_edge(vertex, nearby_vertex);
             connect(new_edge);
-            connect(vertex);
             used_vertices.insert(nearby_vertex);
             new_edges.insert(new_edge);
 
             connected = true;
-
-            // check if the new edge have any sibling edges
-            for (const auto& sibling_vertex : vertex->get_sibling_vertices())
-            {
-                for (const auto& edge : sibling_vertex->get_edges())
-                {
-                    if (edge->has_vertex(nearby_vertex))
-                    {
-                        new_edge->connect(edge);
-                    }
-                }
-            }
         }
     }
 
@@ -788,18 +773,6 @@ bool Surface::connect_by_edges_and_faces(const std::shared_ptr<Vertex>& vertex, 
             // if face not already exists, create face
             std::shared_ptr<Face> new_face = storage_->add_face(shared_from_this(), vertex, nearby_vertex0, nearby_vertex1);
             new_faces.insert(new_face);
-
-            // connnect new face to its sibling faces
-            for (const auto& sibling_edge : existing_edge->get_sibling_edges())
-            {
-                for (const auto& sibling_face : sibling_edge->get_faces())
-                {
-                    if (sibling_face->has_vertex(vertex))
-                    {
-                        new_face->connect(sibling_face);
-                    }
-                }
-            }
         }
     }
 

--- a/src/MeshObject/Surface.cpp
+++ b/src/MeshObject/Surface.cpp
@@ -848,7 +848,11 @@ void Surface::connect(const std::shared_ptr<Edge>& edge)
 
     // connect
     bool inserted = edges_.insert(edge).second;
-    if (inserted) edge->connect(shared_from_this());
+    if (inserted) 
+    {
+        add_searchable_edge(edge);
+        edge->connect(shared_from_this());
+    }
 }
 
 void Surface::connect(const std::shared_ptr<Face>& face)
@@ -914,7 +918,11 @@ void Surface::disconnect(const std::shared_ptr<Edge>& edge)
 
     // disconnect
     bool erased = edges_.erase(edge);
-    if (erased) edge->disconnect(shared_from_this());
+    if (erased) 
+    {
+        remove_searchable_edge(edge);
+        edge->disconnect(shared_from_this());
+    }
 }
 
 void Surface::disconnect(const std::shared_ptr<Face>& face)

--- a/src/MeshObject/Vertex.cpp
+++ b/src/MeshObject/Vertex.cpp
@@ -147,9 +147,16 @@ const int& Vertex::get_id() const
     return id_; 
 }
 
-const Eigen::Vector3d& Vertex::get_position() const 
+const Eigen::Vector3d& Vertex::get_original_position() const 
 { 
     return position_; 
+}
+
+const Eigen::Vector3d& Vertex::get_position() const 
+{ 
+    if (projected_position_.isZero()) throw std::runtime_error("Vertex projected position is not set.");
+    
+    return projected_position_;
 }
 
 const Eigen::Vector3d& Vertex::buffer_compute_projected_position(const std::shared_ptr<Surface> surface)
@@ -162,7 +169,7 @@ const Eigen::Vector3d& Vertex::buffer_compute_projected_position(const std::shar
     // add to cache if not exist
     if (!buffer_projected_position_.exists(hash)) 
     {
-        const Eigen::Vector3d computedResult = surface->compute_point_projective_position(get_origin(), get_position());
+        const Eigen::Vector3d computedResult = surface->compute_point_projective_position(get_origin(), get_original_position());
         buffer_projected_position_.put(hash, computedResult);
     }
 
@@ -180,7 +187,7 @@ const double& Vertex::buffer_compute_projected_distance(const std::shared_ptr<Su
     // add to cache if not exist
     if (!buffer_projected_distance_.exists(hash)) 
     {
-        const double computedResult = surface->compute_point_projective_distance(get_origin(), get_position());
+        const double computedResult = surface->compute_point_projective_distance(get_origin(), get_original_position());
         buffer_projected_distance_.put(hash, computedResult);
     }
 
@@ -333,7 +340,7 @@ const Eigen::Vector2d& Vertex::get_surface_coordinate(const std::shared_ptr<Surf
     {
         // compute new coordinate
         Eigen::Matrix<double, 3, 2> projection_matrix = eigenvectors.rightCols<2>();
-        Eigen::Vector3d projected_position = surface->compute_point_projective_position(get_origin(), get_position());
+        Eigen::Vector3d projected_position = surface->compute_point_projective_position(get_origin(), get_original_position());
         surface_coordinate_ = (projection_matrix.transpose() * projected_position).head<2>();
         eigenvectors_used_ = eigenvectors;
         return surface_coordinate_;
@@ -435,6 +442,9 @@ void Vertex::connect(const std::shared_ptr<Surface>& surface)
     if (inserted) surface_ = surface;
     if (inserted) 
     {
+        // update projected position
+        projected_position_ = surface->compute_point_projective_position(get_origin(), get_original_position());
+
         // if new surface is the same as the previous surface, set the radius to the updated previous radius
         if (surface == previous_surface_) 
         {
@@ -523,6 +533,7 @@ void Vertex::disconnect(const std::shared_ptr<Surface>& surface)
     if (erased) is_boundary_ = false;
     if (erased) is_singular_ = false;
     if (erased) surface_ = nullptr;
+    if (erased) projected_position_ = Eigen::Vector3d::Zero();
 
     // check self destruct
     if (!deleting_ && erased && can_self_destruct_) storage_->delete_vertex(shared_from_this());
@@ -911,6 +922,10 @@ void Vertex::reduce_reverse_radius_search_radius(double radius)
     std::unordered_set<std::shared_ptr<Vertex>, MeshObjectHash> connected_vertices = compute_connected_vertices();
     for (const std::shared_ptr<Vertex>& vertex : connected_vertices)
     {
+        // this vertex and or connected vertices could be expired during the process
+        if (vertex->is_expired()) continue;
+        if (is_expired()) return;
+
         // distance
         double distance = (vertex->get_position() - get_position()).norm();
         


### PR DESCRIPTION
### Changes
- **robust edge intersection checks**
  - Previously, edge intersection checks were limited to boundary edges.
  - Now, they are performed against all edges for more robust result
  - the speed is not decreased
- **projected points**
  - Edges and faces now uses the projected points.  
  - This ensures mesh expansion and mesh intersection operations consistently use the same type of points.
- **edges are required to add to surface**
  - When connecting a point to a surface, if no edge is formed, the points are removed from the original surface and assigned to a new surface.  
  - This approach reduces the occurrence of singular points.