### PR TITLE
22 improve mesh expansion

### DIFF
--- a/include/MeshObject/Application.hpp
+++ b/include/MeshObject/Application.hpp
@@ -86,6 +86,8 @@ private:
     std::chrono::time_point<std::chrono::high_resolution_clock> t_init;
     std::chrono::time_point<std::chrono::high_resolution_clock> t_last;
     std::mutex t_last_mutex;
+    double total_duration;
+    unsigned int total_loops;
 
     std::unordered_map<std::shared_ptr<Surface>, unsigned int, MeshObjectHash> surface_to_contention_count;
 };

--- a/include/MeshObject/Face.hpp
+++ b/include/MeshObject/Face.hpp
@@ -78,7 +78,6 @@ private:
     Eigen::Vector3d center_;
 
     bool deleting_ = false;
-    bool is_searchable_ = false;
     bool is_expired_ = true;
     bool is_confirmed_ = false;
 

--- a/include/MeshObject/Settings.hpp
+++ b/include/MeshObject/Settings.hpp
@@ -1,6 +1,7 @@
 #pragma once
 
 #include <string>
+#include <ostream>
 
 struct LOG
 {
@@ -34,6 +35,33 @@ enum class ColorMode
     DISTANCE_TRAVELLED,
     WEIGHT
 };
+
+enum class PointMode
+{
+    USED,
+    ORIGINAL,
+    PROJECTED
+};
+
+inline std::ostream& operator<<(std::ostream& os, const PointMode& mode)
+{
+    switch (mode)
+    {
+        case PointMode::USED:
+            os << "   USED   |          |           |";
+            break;
+        case PointMode::ORIGINAL:
+            os << "          | ORIGINAL |           |";
+            break;
+        case PointMode::PROJECTED:
+            os << "          |          | PROJECTED |";
+            break;
+        default:
+            os << "not set";
+            break;
+    }
+    return os;
+}
 
 struct DataLoader_Settings
 {
@@ -99,12 +127,12 @@ struct Settings
     bool show_pointcloud;
     bool show_triangle;
     bool show_edge;
-    bool show_projected_point;
     bool show_confirmed_only;
     bool show_keycode;
     bool show_singular_edge;
     bool show_singular_vertex;
     ColorMode color_mode;
+    PointMode point_mode;
     double surface_denominator;
     double siblings_denominator;
     double radius_denominator;

--- a/include/MeshObject/Storage.hpp
+++ b/include/MeshObject/Storage.hpp
@@ -68,8 +68,8 @@ public: // to user
     void clear_queues();
 
     void add_points_in_add_searchable_vertex_queue();
-    void add_points_in_affected_vertices_set();
-    void add_faces_in_affected_faces_set();
+    void add_or_remove_vertices_from_rrs_tree();
+    void add_or_remove_faces_from_bvh_tree();
 
     bool can_reverse_radius_search();
     RRSReturnType reverse_radius_search(const std::shared_ptr<GenericPoint>& generic_point, std::vector<std::shared_ptr<Vertex>>& result);
@@ -100,8 +100,8 @@ private: // to Vertex and Face class
     void add_searchable_vertex(const std::shared_ptr<Vertex>& vertex);
     void remove_searchable_vertex(const std::shared_ptr<Vertex>& vertex);
 
-    void add_affected_vertex(const std::shared_ptr<Vertex>& vertex);
-    void add_affected_face(const std::shared_ptr<Face>& face);
+    void add_to_set_of_vertices_to_update_rrs_tree(const std::shared_ptr<Vertex>& vertex);
+    void add_to_set_of_faces_to_update_bvh_tree(const std::shared_ptr<Face>& face);
 
     void add_searchable_face(const std::shared_ptr<Face>& face);
     void remove_searchable_face(const std::shared_ptr<Face>& face);
@@ -130,8 +130,8 @@ private:
     unsigned int num_delete_before_put_to_repeated_queue_ = 2;
 
     std::vector<std::queue<std::shared_ptr<Vertex>>> smaller_add_searchable_vertices_queue_;
-    std::vector<std::unordered_set<std::shared_ptr<Vertex>, MeshObjectHash>> smaller_affected_vertices_sets_;
-    std::vector<std::unordered_set<std::shared_ptr<Face>, MeshObjectHash>> smaller_affected_faces_sets_;
+    std::vector<std::unordered_set<std::shared_ptr<Vertex>, MeshObjectHash>> smaller_set_of_vertices_to_update_rrs_tree;
+    std::vector<std::unordered_set<std::shared_ptr<Face>, MeshObjectHash>> smaller_set_of_faces_to_update_rrs_tree;
 
     std::unordered_set<std::shared_ptr<Vertex>, MeshObjectHash> vertices_;
     std::unordered_set<std::shared_ptr<Edge>, MeshObjectHash> edges_;

--- a/include/MeshObject/Vertex.hpp
+++ b/include/MeshObject/Vertex.hpp
@@ -89,8 +89,7 @@ public:
     void swap(const std::shared_ptr<Surface>& surface1, const std::shared_ptr<Surface>& surface2);
     void absorbs(const std::shared_ptr<Vertex>& input_vertex);
 
-    void update_boundary_state();
-    void update_searchable_state();
+    void check_if_update_search_tree();
 
     void print_info();
 
@@ -118,8 +117,6 @@ private:
 
     bool deleting_ = false;
     bool under_review_ = false;
-    bool is_boundary_;
-    bool is_searchable_ = false;
     bool is_expired_ = true;
     bool is_singular_;
     bool can_self_destruct_ = true;

--- a/src/MeshObject/Application.cpp
+++ b/src/MeshObject/Application.cpp
@@ -908,13 +908,19 @@ pcl::PointCloud<pcl::PointXYZRGB>::Ptr Application<PointT>::compute_interior_poi
         if (settings.show_confirmed_only && !interior_point->is_confirmed()) continue;
         
         pcl::PointXYZRGB point;
-        if (settings.show_projected_point)
+        if (settings.point_mode == PointMode::PROJECTED)
         {
             point.x = interior_point->buffer_compute_projected_position()[0];
             point.y = interior_point->buffer_compute_projected_position()[1];
             point.z = interior_point->buffer_compute_projected_position()[2];
         }
-        else
+        else if (settings.point_mode == PointMode::ORIGINAL)
+        {
+            point.x = interior_point->get_original_position()[0];
+            point.y = interior_point->get_original_position()[1];
+            point.z = interior_point->get_original_position()[2];
+        }
+        else if (settings.point_mode == PointMode::USED)
         {
             point.x = interior_point->get_position()[0];
             point.y = interior_point->get_position()[1];
@@ -1064,13 +1070,19 @@ pcl::PointCloud<pcl::PointXYZRGB>::Ptr Application<PointT>::compute_vertex_point
         if (!setting.show_singular_vertex && vertex->is_singular()) continue;
 
         pcl::PointXYZRGB point;
-        if (setting.show_projected_point)
+        if (setting.point_mode == PointMode::PROJECTED)
         {
             point.x = vertex->buffer_compute_projected_position()[0];
             point.y = vertex->buffer_compute_projected_position()[1];
             point.z = vertex->buffer_compute_projected_position()[2];
         }
-        else
+        else if (setting.point_mode == PointMode::ORIGINAL)
+        {
+            point.x = vertex->get_original_position()[0];
+            point.y = vertex->get_original_position()[1];
+            point.z = vertex->get_original_position()[2];
+        }
+        else if (setting.point_mode == PointMode::USED)
         {
             point.x = vertex->get_position()[0];
             point.y = vertex->get_position()[1];

--- a/src/MeshObject/Application.cpp
+++ b/src/MeshObject/Application.cpp
@@ -618,6 +618,8 @@ bool Application<PointT>::add_point_by_radius_search(const std::shared_ptr<Gener
             }
             else
             {
+                // need to prevent this vertex from generating a new generic point
+                new_vertex->can_create_generic_point(false);
                 storage_->delete_vertex(new_vertex);
                 continue;
             }
@@ -672,6 +674,8 @@ bool Application<PointT>::add_point_by_radius_search(const std::shared_ptr<Gener
             }
             else
             {
+                // need to prevent this vertex from generating a new generic point
+                new_vertex->can_create_generic_point(false);
                 storage_->delete_vertex(new_vertex);
                 continue;
             }

--- a/src/MeshObject/Application.cpp
+++ b/src/MeshObject/Application.cpp
@@ -362,8 +362,8 @@ void Application<PointT>::process_point(const std::shared_ptr<GenericPoint>& gen
     num_of_concurrent_processes--;
     
     // after unlocking all locks, add the point in queue to the search tree
-    storage_->add_points_in_affected_vertices_set();
-    storage_->add_faces_in_affected_faces_set();
+    storage_->add_or_remove_vertices_from_rrs_tree();
+    storage_->add_or_remove_faces_from_bvh_tree();
 
     //
     // they all lead to return, thus unlock all locks

--- a/src/MeshObject/Application.cpp
+++ b/src/MeshObject/Application.cpp
@@ -791,7 +791,9 @@ void Application<PointT>::loop()
 
     std::chrono::high_resolution_clock::time_point t_end = std::chrono::high_resolution_clock::now();
     std::chrono::duration<double> duration = t_end - t_init;
-    std::cout << "==================================================================== Processed " << accumulated_points << " points in " << duration.count() << " s" << std::endl;
+    total_duration += duration.count();
+    total_loops += 1;
+    std::cout << "==================================================================== Processed " << accumulated_points << " points in " << duration.count() << " s, " << "average duration: " << total_duration / total_loops << std::endl;
 
     // store time and ith_cloud into file
     if (settings_.output_time)
@@ -835,6 +837,9 @@ void Application<PointT>::restart()
     ith_size = 0;
     origin = Eigen::Vector3d(0, 0, 0);
     distance_travelled_ = 0;
+
+    total_duration = 0;
+    total_loops = 0;
     
     // load point cloud
     load_point_cloud();

--- a/src/MeshObject/Application.cpp
+++ b/src/MeshObject/Application.cpp
@@ -592,69 +592,94 @@ bool Application<PointT>::add_point_by_radius_search(const std::shared_ptr<Gener
         if (distance < new_point_radius) new_point_radius = distance;
     }
 
-    // decide surface_to_add_to
+    // try add to surfaces_within
     if (surfaces_within.size() > 0)
     {
-        // add to largest surface
-        unsigned int largest_surface_size = 0;
-        for (std::shared_ptr<Surface> surface : surfaces_within)
-        {
-            if (surface->get_total_point_size() > largest_surface_size)
-            {
-                largest_surface_size = surface->get_total_point_size();
-                surface_to_add_to = surface;
-            }
-        }
-    }
-    else if (surfaces_seed.size() > 0)
-    {
-        // add to the closest surface measured by point to point distance
-        double smallest_distance = std::numeric_limits<double>::max();
-        
-        // for each vertex
-        for (std::shared_ptr<Vertex> vertex : all_vertices)
-        {
-            // skip if expired
-            if (vertex->is_expired()) continue;
+        // sort by surface size
+        std::vector<std::shared_ptr<Surface>> surfaces_within_sorted(surfaces_within.begin(), surfaces_within.end());
+        std::sort(surfaces_within_sorted.begin(), surfaces_within_sorted.end(), 
+            [](const std::shared_ptr<Surface>& a, const std::shared_ptr<Surface>& b) { return a->get_total_point_size() > b->get_total_point_size(); });
 
-            // this surface
-            std::shared_ptr<Surface> this_surface = vertex->get_surface();
+        // for each surface
+        for (std::shared_ptr<Surface> surface : surfaces_within_sorted)
+        {
+            // try to add to the surface
+            surface_to_add_to = surface;
+
+            // add to surface_to_add_to
+            std::shared_ptr<Vertex> new_vertex = storage_->add_vertex(surface_to_add_to, generic_point);
+            new_vertex->reduce_reverse_radius_search_radius(new_point_radius);
+            new_vertex->reduce_previous_radius(new_point_radius);
+            const bool connected = surface_to_add_to->connect_by_edges_and_faces(new_vertex, all_vertices);
             
-            // skip if the face is not in surfaces_seed
-            if (surfaces_seed.find(this_surface) == surfaces_seed.end()) continue;
-
-            // compute distance
-            double distance = (vertex->get_position() - generic_point->get_position()).norm();
-            if (distance < smallest_distance)
+            if (connected)
             {
-                smallest_distance = distance;
-                surface_to_add_to = this_surface;
+                return true;
+            }
+            else
+            {
+                storage_->delete_vertex(new_vertex);
+                continue;
             }
         }
     }
-    else
-    {
-        // add to new surface (when no surfaces within nor seed)
-        return false;
-    }
 
-    // add to surface_to_add_to
-    std::shared_ptr<Vertex> new_vertex = storage_->add_vertex(surface_to_add_to, generic_point);
-    new_vertex->reduce_reverse_radius_search_radius(new_point_radius);
-    new_vertex->reduce_previous_radius(new_point_radius);
-    const bool connected = surface_to_add_to->connect_by_edges_and_faces(new_vertex, all_vertices);
+    // try add to surfaces_seed
+    if (surfaces_seed.size() > 0)
+    {        
+        // compute surfaces_seed distances
+        std::unordered_map<std::shared_ptr<Surface>, double, MeshObjectHash> surfaces_seed_distances;
+        for (std::shared_ptr<Surface> surface : surfaces_seed)
+        {
+            for (std::shared_ptr<Vertex> vertex : all_vertices)
+            {
+                // skip if the vertex is expired
+                if (vertex->is_expired()) continue;
+
+                // skip if the vertex is not in surfaces_seed
+                if (vertex->get_surface() != surface) continue;
+
+                // compute distance
+                double distance_vertex = (vertex->get_position() - generic_point->get_position()).norm();
+                if (distance_vertex < surfaces_seed_distances[surface])
+                {
+                    surfaces_seed_distances[surface] = distance_vertex;
+                }
+            }
+        }
+
+        // sort by surface closeness
+        std::vector<std::shared_ptr<Surface>> surfaces_seed_sorted(surfaces_seed.begin(), surfaces_seed.end());
+        std::sort(surfaces_seed_sorted.begin(), surfaces_seed_sorted.end(), 
+            [&surfaces_seed_distances](const std::shared_ptr<Surface>& a, const std::shared_ptr<Surface>& b) { return surfaces_seed_distances[a] < surfaces_seed_distances[b]; });
+
+
+        // for each surface
+        for (std::shared_ptr<Surface> surface : surfaces_seed_sorted)
+        {
+            // try to add to the surface
+            surface_to_add_to = surface;
+
+            // add to surface_to_add_to
+            std::shared_ptr<Vertex> new_vertex = storage_->add_vertex(surface_to_add_to, generic_point);
+            new_vertex->reduce_reverse_radius_search_radius(new_point_radius);
+            new_vertex->reduce_previous_radius(new_point_radius);
+            const bool connected = surface_to_add_to->connect_by_edges_and_faces(new_vertex, all_vertices);
+            
+            if (connected)
+            {
+                return true;
+            }
+            else
+            {
+                storage_->delete_vertex(new_vertex);
+                continue;
+            }
+        }
+    }
     
-    // there are singular points of a surface that are not connected to any other points
-    // perhaps this is the cause.
-    // if not connected, delete this point 
-    if (!connected)
-    {
-        storage_->delete_vertex(new_vertex);
-        return false;
-    }
-
-    // else
-    return true;
+    // add to new surface (when no surfaces within nor seed)
+    return false;
 }
 
 template <typename PointT>

--- a/src/MeshObject/Edge.cpp
+++ b/src/MeshObject/Edge.cpp
@@ -332,7 +332,7 @@ void Edge::update_boundary_state()
         // update connected vertices
         for (const std::shared_ptr<Vertex>& vertex : vertices_)
         {
-            vertex->update_boundary_state();
+            vertex->check_if_update_search_tree();
         }
     }
 }

--- a/src/MeshObject/Face.cpp
+++ b/src/MeshObject/Face.cpp
@@ -94,7 +94,7 @@ void Face::initialize_(const std::shared_ptr<Storage>& storage, const std::share
 
     // add to search
     // storage_->add_searchable_face(shared_from_this());
-    storage_->add_affected_face(shared_from_this());
+    storage_->add_to_set_of_faces_to_update_bvh_tree(shared_from_this());
 
     // log
     if (settings_.log.initialize) std::cout << "Face " << id_ << " created between vertex " << vertex0->get_id() << ", vertex " << vertex1->get_id() << " and vertex " << vertex2->get_id() << std::endl;
@@ -140,7 +140,7 @@ void Face::delete_()
     }
 
     // add to affected faces set
-    storage_->add_affected_face(shared_from_this());
+    storage_->add_to_set_of_faces_to_update_bvh_tree(shared_from_this());
 
     // log
     if (settings_.log.deletion) std::cout << "Destroying face " << id_ << std::endl;

--- a/src/MeshObject/Face.cpp
+++ b/src/MeshObject/Face.cpp
@@ -95,7 +95,6 @@ void Face::initialize_(const std::shared_ptr<Storage>& storage, const std::share
     // add to search
     // storage_->add_searchable_face(shared_from_this());
     storage_->add_affected_face(shared_from_this());
-    is_searchable_ = true;
 
     // log
     if (settings_.log.initialize) std::cout << "Face " << id_ << " created between vertex " << vertex0->get_id() << ", vertex " << vertex1->get_id() << " and vertex " << vertex2->get_id() << std::endl;
@@ -141,7 +140,6 @@ void Face::delete_()
     }
 
     // add to affected faces set
-    is_searchable_ = false;
     storage_->add_affected_face(shared_from_this());
 
     // log
@@ -254,7 +252,7 @@ bool Face::is_expired() const
 
 bool Face::is_searchable() const
 {
-    return is_searchable_;
+    return node != nullptr;
 }
 
 bool Face::has_vertex(const std::shared_ptr<Vertex>& vertex) const

--- a/src/MeshObject/InteractiveViewer.cpp
+++ b/src/MeshObject/InteractiveViewer.cpp
@@ -380,11 +380,23 @@ void InteractiveViewer<PointT>::keyboard_callback(const pcl::visualization::Keyb
     }
     if (event.getKeySym() == "a" && event.keyDown())
     {
-        settings_.show_projected_point = !settings_.show_projected_point;
+        // loop around the point mode
+        if (settings_.point_mode == PointMode::USED)
+        {
+            settings_.point_mode = PointMode::ORIGINAL;
+        }
+        else if (settings_.point_mode == PointMode::ORIGINAL)
+        {
+            settings_.point_mode = PointMode::PROJECTED;
+        }
+        else if (settings_.point_mode == PointMode::PROJECTED)
+        {
+            settings_.point_mode = PointMode::USED;
+        }
         update_display();
 
         // log
-        std::cout << "show_projected_point: " << settings_.show_projected_point << std::endl;
+        std::cout << "point mode: " << settings_.point_mode << std::endl;
     }
     if (event.getKeySym() == "z" && event.keyDown())
     {

--- a/src/MeshObject/RRSTree.cpp
+++ b/src/MeshObject/RRSTree.cpp
@@ -611,8 +611,11 @@ RRSReturnType RRSTree::node_reverse_radius_search(const std::shared_ptr<RRSNode>
             return RRSReturnType::ABORT;
         }
         
-        // skip if boundary vertex is not searchable ( this mean the vertex should be removed from node but has not been removed yet)
-        if (!node->boundary_vertices[0]->is_searchable())
+        // we lock the vertex during vertex->delete_() call, and then release it before locking it again when removing it from the rrs tree
+        // thus this thread may have lock this vertex during the gap
+        // and see an expired vertex in the search tree
+        // thus we need to check if the vertex is expired and skip if it is
+        if (node->boundary_vertices[0]->is_expired())
         {
             omp_unset_nest_lock(&boundary_vertex->vertex_lock);
             omp_unset_nest_lock(&node->omp_lock);

--- a/src/MeshObject/Settings.cpp
+++ b/src/MeshObject/Settings.cpp
@@ -75,7 +75,7 @@ Settings::Settings()
 
     num_of_delete_before_put_to_repeated_queue = 2;
     
-    num_threads = 30;
+    num_threads = 4;
     record_countent_surface_count = false;
 
     use_queue = true;

--- a/src/MeshObject/Settings.cpp
+++ b/src/MeshObject/Settings.cpp
@@ -136,12 +136,12 @@ Settings::Settings()
     show_pointcloud = true;
     show_triangle = true;
     show_edge = true;
-    show_projected_point = false;
     show_confirmed_only = false;
     show_keycode = false;
     show_singular_edge = false;
     show_singular_vertex = false;
     color_mode = ColorMode::ID;
+    point_mode = PointMode::USED;
     surface_denominator = 10.0;
     siblings_denominator = 3.0;
     radius_denominator = 0.3;

--- a/src/MeshObject/Storage.cpp
+++ b/src/MeshObject/Storage.cpp
@@ -689,8 +689,9 @@ void Storage::add_faces_in_affected_faces_set()
 {
     for (const std::shared_ptr<Face>& face : smaller_affected_faces_sets_[omp_get_thread_num()])
     {
-        // skip if face is expired, but really there should not have been any expired face in the set
-        if (face->is_expired()) continue;
+        // this should allow face to be expired. since when deleting face, it will become expired.
+        // // skip if face is expired, but really there should not have been any expired face in the set
+        // if (face->is_expired()) continue;
 
         // i need a explicit flag that indicates if the vertex is added to the rrs tree or not, instead of just a is_searchable flag
 

--- a/src/MeshObject/Storage.cpp
+++ b/src/MeshObject/Storage.cpp
@@ -656,21 +656,29 @@ void Storage::add_points_in_affected_vertices_set()
         // if (vertex->is_expired()) continue;
 
         // check if vertex needs to be added or removed or unchanged from rrs_tree
-        if (vertex->is_boundary() && vertex->node == nullptr)
+        if (vertex->is_expired())
         {
-            // add to rrs_tree
-            rrs_tree_.tree_add_vertex(vertex);
+            if (vertex->is_searchable())
+            {
+                rrs_tree_.tree_delete_vertex(vertex);
+            }
+            else
+            {
+                // do nothing
+            }
         }
-        else if (!vertex->is_boundary() && vertex->node != nullptr)
+        else
         {
-            // remove from rrs_tree
-            rrs_tree_.tree_delete_vertex(vertex);
-        }
+            if (vertex->is_boundary() && !vertex->is_searchable())
+            {
+                rrs_tree_.tree_add_vertex(vertex);
+            }
 
-        // else
-        // {
-        //     // do nothing
-        // }
+            if (!vertex->is_boundary() && vertex->is_searchable())
+            {
+                rrs_tree_.tree_delete_vertex(vertex);
+            }
+        }
     }
 
     // clear

--- a/src/MeshObject/Storage.cpp
+++ b/src/MeshObject/Storage.cpp
@@ -25,8 +25,8 @@ Storage::Storage()
     smaller_repeated_queues_.resize(settings_.num_threads);
     smaller_abort_queues_.resize(settings_.num_threads);
     smaller_add_searchable_vertices_queue_.resize(settings_.num_threads);
-    smaller_affected_vertices_sets_.resize(settings_.num_threads);
-    smaller_affected_faces_sets_.resize(settings_.num_threads);
+    smaller_set_of_vertices_to_update_rrs_tree.resize(settings_.num_threads);
+    smaller_set_of_faces_to_update_rrs_tree.resize(settings_.num_threads);
     
     // initialize with queue or stack
     for (size_t i = 0; i < settings_.num_threads; ++i)
@@ -647,9 +647,9 @@ void Storage::add_points_in_add_searchable_vertex_queue()
     }
 }
 
-void Storage::add_points_in_affected_vertices_set()
+void Storage::add_or_remove_vertices_from_rrs_tree()
 {
-    for (const std::shared_ptr<Vertex>& vertex : smaller_affected_vertices_sets_[omp_get_thread_num()])
+    for (const std::shared_ptr<Vertex>& vertex : smaller_set_of_vertices_to_update_rrs_tree[omp_get_thread_num()])
     {
         // this should allow vertex to be expired. since when deleting vertex, it will become expired.
         // // skip if vertex is expired, but really we should reduce the number of expired vertex in the set
@@ -682,12 +682,12 @@ void Storage::add_points_in_affected_vertices_set()
     }
 
     // clear
-    smaller_affected_vertices_sets_[omp_get_thread_num()].clear();
+    smaller_set_of_vertices_to_update_rrs_tree[omp_get_thread_num()].clear();
 }
 
-void Storage::add_faces_in_affected_faces_set()
+void Storage::add_or_remove_faces_from_bvh_tree()
 {
-    for (const std::shared_ptr<Face>& face : smaller_affected_faces_sets_[omp_get_thread_num()])
+    for (const std::shared_ptr<Face>& face : smaller_set_of_faces_to_update_rrs_tree[omp_get_thread_num()])
     {
         // this should allow face to be expired. since when deleting face, it will become expired.
         // // skip if face is expired, but really there should not have been any expired face in the set
@@ -717,7 +717,7 @@ void Storage::add_faces_in_affected_faces_set()
     }
 
     // clear
-    smaller_affected_faces_sets_[omp_get_thread_num()].clear();
+    smaller_set_of_faces_to_update_rrs_tree[omp_get_thread_num()].clear();
 }
 
 
@@ -727,16 +727,16 @@ void Storage::remove_searchable_vertex(const std::shared_ptr<Vertex>& vertex)
     rrs_tree_.tree_delete_vertex(vertex);
 }
 
-void Storage::add_affected_vertex(const std::shared_ptr<Vertex>& vertex)
+void Storage::add_to_set_of_vertices_to_update_rrs_tree(const std::shared_ptr<Vertex>& vertex)
 {
     // add to affected vertices set
-    smaller_affected_vertices_sets_[omp_get_thread_num()].insert(vertex);
+    smaller_set_of_vertices_to_update_rrs_tree[omp_get_thread_num()].insert(vertex);
 }
 
-void Storage::add_affected_face(const std::shared_ptr<Face>& face)
+void Storage::add_to_set_of_faces_to_update_bvh_tree(const std::shared_ptr<Face>& face)
 {
     // add to affected vertices set
-    smaller_affected_faces_sets_[omp_get_thread_num()].insert(face);
+    smaller_set_of_faces_to_update_rrs_tree[omp_get_thread_num()].insert(face);
 }
 
 void Storage::add_searchable_face(const std::shared_ptr<Face>& face)

--- a/src/MeshObject/Storage.cpp
+++ b/src/MeshObject/Storage.cpp
@@ -651,10 +651,9 @@ void Storage::add_points_in_affected_vertices_set()
 {
     for (const std::shared_ptr<Vertex>& vertex : smaller_affected_vertices_sets_[omp_get_thread_num()])
     {
-        // skip if vertex is expired, but really we should reduce the number of expired vertex in the set
-        if (vertex->is_expired()) continue;
-
-        // i need a explicit flag that indicates if the vertex is added to the rrs tree or not, instead of just a is_searchable flag
+        // this should allow vertex to be expired. since when deleting vertex, it will become expired.
+        // // skip if vertex is expired, but really we should reduce the number of expired vertex in the set
+        // if (vertex->is_expired()) continue;
 
         // check if vertex needs to be added or removed or unchanged from rrs_tree
         if (vertex->is_boundary() && vertex->node == nullptr)

--- a/src/MeshObject/Storage.cpp
+++ b/src/MeshObject/Storage.cpp
@@ -693,24 +693,27 @@ void Storage::add_faces_in_affected_faces_set()
         // // skip if face is expired, but really there should not have been any expired face in the set
         // if (face->is_expired()) continue;
 
-        // i need a explicit flag that indicates if the vertex is added to the rrs tree or not, instead of just a is_searchable flag
-
-        // check if vertex needs to be added or removed or unchanged from rrs_tree
-        if (face->is_searchable() && face->node == nullptr)
+        if (face->is_expired())
         {
-            // add to rrs_tree
-            triangle_bvh_.tree_add_face(face);
+            if (face->is_searchable())
+            {
+                // remove from rrs_tree
+                triangle_bvh_.tree_delete_face(face);
+            }
+            else
+            {
+                // do nothing
+            }
         }
-        else if (!face->is_searchable() && face->node != nullptr)
+        else
         {
-            // remove from rrs_tree
-            triangle_bvh_.tree_delete_face(face);
+            // face should always be searchable
+            if (!face->is_searchable())
+            {
+                // add to rrs_tree
+                triangle_bvh_.tree_add_face(face);
+            }
         }
-
-        // else
-        // {
-        //     // do nothing
-        // }
     }
 
     // clear

--- a/src/MeshObject/TriangleBVH.cpp
+++ b/src/MeshObject/TriangleBVH.cpp
@@ -293,8 +293,11 @@ BVHReturnType TriangleBVH::node_intersection_search(const std::shared_ptr<Node>&
             return BVHReturnType::ABORT;
         }
 
-        // skip if face is not searchable
-        if (!node->faces[0]->is_searchable())
+        // we lock the face during face->delete_() call, and then release it before locking it again when removing it from the bvh tree
+        // thus this thread may have lock this face during the gap
+        // and see an expired face in the search tree
+        // thus we need to check if the face is expired and skip if it is
+        if (face->is_expired())
         {
             omp_unset_nest_lock(&face->face_lock);
             omp_unset_nest_lock(&node->omp_lock);

--- a/src/MeshObject/Vertex.cpp
+++ b/src/MeshObject/Vertex.cpp
@@ -88,7 +88,7 @@ void Vertex::delete_()
     }
 
     // add to update rrs tree vertex set
-    storage_->add_affected_vertex(shared_from_this());
+    storage_->add_to_set_of_vertices_to_update_rrs_tree(shared_from_this());
 
     // log
     if (settings_.log.deletion) std::cout << "Destroying vertex " << id_ << std::endl;
@@ -834,11 +834,11 @@ void Vertex::check_if_update_search_tree()
     // check if is boundary
     if (is_boundary() && !is_searchable())
     {
-        storage_->add_affected_vertex(shared_from_this());
+        storage_->add_to_set_of_vertices_to_update_rrs_tree(shared_from_this());
     }
     else if (!is_boundary() && is_searchable())
     {
-        storage_->add_affected_vertex(shared_from_this());
+        storage_->add_to_set_of_vertices_to_update_rrs_tree(shared_from_this());
     }
 }
 

--- a/src/MeshObject/Vertex.cpp
+++ b/src/MeshObject/Vertex.cpp
@@ -37,8 +37,8 @@ void Vertex::initialize_(const std::shared_ptr<Storage>& storage, const std::sha
     // connect
     connect(surface);
 
-    // update boundary state here, in case no edge is connected, the point is still boundary and need to add to rrs tree
-    update_boundary_state();
+    // check if update search tree
+    check_if_update_search_tree();
 
     // set reverse search radius based on input parameter
     set_reverse_radius_search_radius(radius);
@@ -87,8 +87,7 @@ void Vertex::delete_()
         std::cout << "waiting to lock vertex " << id_ << std::endl;
     }
 
-    // add to affected vertices set
-    is_searchable_ = false;
+    // add to update rrs tree vertex set
     storage_->add_affected_vertex(shared_from_this());
 
     // log
@@ -392,12 +391,24 @@ bool Vertex::is_expired() const
 
 bool Vertex::is_boundary() const
 {
-    return is_boundary_;
+    // becomes boundary when one of the connected edges is boundary, or when the point is alone
+    bool is_boundary_flag = false;
+    for (const std::shared_ptr<Edge>& edge : edges_)
+    {
+        if (edge->is_boundary())
+        {
+            is_boundary_flag = true;
+            break;
+        }
+    }
+    if (edges_.empty()) is_boundary_flag = true;
+
+    return is_boundary_flag;
 }
 
 bool Vertex::is_searchable() const
 {
-    return is_searchable_;
+    return node != nullptr;
 }
 
 bool Vertex::is_deleting() const
@@ -415,7 +426,7 @@ void Vertex::connect(const std::shared_ptr<Edge>& edge)
     if (inserted) edge->connect(shared_from_this());
 
     // update boundary state
-    if (inserted) update_boundary_state();
+    if (inserted) check_if_update_search_tree();
 }
 
 void Vertex::connect(const std::shared_ptr<Face>& face) 
@@ -491,7 +502,7 @@ void Vertex::disconnect(const std::shared_ptr<Edge>& edge)
     if (erased) edge->disconnect(shared_from_this());
 
     // update boundary state
-    update_boundary_state();
+    check_if_update_search_tree();
 
     // check self destruct
     if (!deleting_ && edges_.empty()) storage_->delete_vertex(shared_from_this());
@@ -530,7 +541,6 @@ void Vertex::disconnect(const std::shared_ptr<Surface>& surface)
     // disconnect
     bool erased = surface_ == surface;
     if (erased) surface->disconnect(shared_from_this());
-    if (erased) is_boundary_ = false;
     if (erased) is_singular_ = false;
     if (erased) surface_ = nullptr;
     if (erased) projected_position_ = Eigen::Vector3d::Zero();
@@ -819,37 +829,15 @@ void Vertex::absorbs(const std::shared_ptr<Vertex>& input_vertex)
     for (const std::shared_ptr<Edge>& edge : edges_copy) edge->swap(input_vertex, shared_from_this());
 }
 
-void Vertex::update_boundary_state()
-{
-    if (deleting_) return;
-
-    // becomes boundary when one of the connected edges is boundary, or when the point is alone
-    is_boundary_ = false;
-    for (const std::shared_ptr<Edge>& edge : edges_)
-    {
-        if (edge->is_boundary())
-        {
-            is_boundary_ = true;
-            break;
-        }
-    }
-    if (edges_.empty()) is_boundary_ = true;
-
-    // update searchable state
-    update_searchable_state();
-}
-
-void Vertex::update_searchable_state()
+void Vertex::check_if_update_search_tree()
 {
     // check if is boundary
-    if (is_boundary() && !is_searchable_)
+    if (is_boundary() && !is_searchable())
     {
-        is_searchable_ = true;
         storage_->add_affected_vertex(shared_from_this());
     }
-    else if (!is_boundary() && is_searchable_)
+    else if (!is_boundary() && is_searchable())
     {
-        is_searchable_ = false;
         storage_->add_affected_vertex(shared_from_this());
     }
 }
@@ -858,9 +846,9 @@ void Vertex::print_info()
 {
     std::cout << "Vertex " << id_ << " at " << position_.transpose() << std::endl;
     std::cout << "Connected to " << edges_.size() << " edges, " << faces_.size() << " faces, 1 surface, " << sibling_vertices_.size() << " sibling vertices." << std::endl;
-    std::cout << "Boundary state: " << is_boundary_ << std::endl;
+    std::cout << "Boundary state: " << is_boundary() << std::endl;
     std::cout << "Singular state: " << is_singular_ << std::endl;
-    std::cout << "Searchable state: " << is_searchable_ << std::endl;
+    std::cout << "Searchable state: " << is_searchable() << std::endl;
     std::cout << "Expired: " << is_expired_ << std::endl;
 }
 


### PR DESCRIPTION
### Changes  

- **Average Duration**  
  - Added code to compute the average duration.  

- **Add to Next Surface**  
  - Modified behavior to remove a vertex from the current surface and add it to the next largest surface if adding it to the current surface results in long edges.  

- **Fix Skip Expired**  
  - Ensured that expired elements are not skipped when adding affected vertices or faces to the search tree.  

- **Fix Duplicate Generic Points**  
  - Resolved a bug where unintended singular points were created due to duplicate generic points.  

- **Add Point Mode**  
  - Introduced a point mode to toggle between `USED`, `ORIGINAL`, and `PROJECTED`.  

- **Change Number of Threads**  
  - Reduced the number of threads from 30 to 4 to improve speed.  