### PR TITLE
37 remove non manifold structure

### DIFF
--- a/include/MeshObject/Application.hpp
+++ b/include/MeshObject/Application.hpp
@@ -47,6 +47,7 @@ public:
     void rebuild_tree();
     void cleanup_surfaces();
     void remove_non_manifold_edges();
+    void remove_non_manifold_vertices();
 
     // getter
     pcl::PointCloud<pcl::PointXYZRGB>::Ptr compute_vertex_point_pointcloud(const Settings& settings);

--- a/include/MeshObject/Application.hpp
+++ b/include/MeshObject/Application.hpp
@@ -45,6 +45,7 @@ public:
     void process_the_rest();
     void restart();
     void rebuild_tree();
+    void cleanup_surfaces();
 
     // getter
     pcl::PointCloud<pcl::PointXYZRGB>::Ptr compute_vertex_point_pointcloud(const Settings& settings);

--- a/include/MeshObject/Application.hpp
+++ b/include/MeshObject/Application.hpp
@@ -46,6 +46,7 @@ public:
     void restart();
     void rebuild_tree();
     void cleanup_surfaces();
+    void remove_non_manifold_edges();
 
     // getter
     pcl::PointCloud<pcl::PointXYZRGB>::Ptr compute_vertex_point_pointcloud(const Settings& settings);

--- a/include/MeshObject/Application.hpp
+++ b/include/MeshObject/Application.hpp
@@ -48,6 +48,7 @@ public:
     void cleanup_surfaces();
     void remove_non_manifold_edges();
     void remove_non_manifold_vertices();
+    void update_radius();
 
     // getter
     pcl::PointCloud<pcl::PointXYZRGB>::Ptr compute_vertex_point_pointcloud(const Settings& settings);

--- a/include/MeshObject/Application.hpp
+++ b/include/MeshObject/Application.hpp
@@ -45,10 +45,7 @@ public:
     void process_the_rest();
     void restart();
     void rebuild_tree();
-    void cleanup_surfaces();
-    void remove_non_manifold_edges();
-    void remove_non_manifold_vertices();
-    void update_radius();
+    std::shared_ptr<Storage> get_storage();
 
     // getter
     pcl::PointCloud<pcl::PointXYZRGB>::Ptr compute_vertex_point_pointcloud(const Settings& settings);

--- a/include/MeshObject/Edge.hpp
+++ b/include/MeshObject/Edge.hpp
@@ -41,6 +41,8 @@ public:
     void disconnect(const std::shared_ptr<Surface>& surface);
     void disconnect(const std::shared_ptr<Edge>& sibling_edge);
 
+    bool is_connected_to_boundary_edges(std::unordered_set<std::shared_ptr<Face>, MeshObjectHash>& all_connected_faces, std::unordered_set<std::shared_ptr<Edge>, MeshObjectHash>& all_connected_edges) const;
+
     void swap(const std::shared_ptr<Vertex>& vertex1, const std::shared_ptr<Vertex>& vertex2);
 
     void update_confirmed_status();

--- a/include/MeshObject/Edge.hpp
+++ b/include/MeshObject/Edge.hpp
@@ -57,6 +57,8 @@ public:
     void update_searchable_state();
     void remove_searchable_state();
 
+    bool is_non_manifold() const;
+
     bool intersects_edge(const std::shared_ptr<Surface>& surface, const std::shared_ptr<Vertex>& vertex0, const std::shared_ptr<Vertex>& vertex1);
 
 private:

--- a/include/MeshObject/Edge.hpp
+++ b/include/MeshObject/Edge.hpp
@@ -41,6 +41,8 @@ public:
     void disconnect(const std::shared_ptr<Surface>& surface);
     void disconnect(const std::shared_ptr<Edge>& sibling_edge);
 
+    void set_can_self_destruct(bool can_self_destruct);
+
     bool is_connected_to_boundary_edges(std::unordered_set<std::shared_ptr<Face>, MeshObjectHash>& all_connected_faces, std::unordered_set<std::shared_ptr<Edge>, MeshObjectHash>& all_connected_edges) const;
 
     void swap(const std::shared_ptr<Vertex>& vertex1, const std::shared_ptr<Vertex>& vertex2);

--- a/include/MeshObject/Face.hpp
+++ b/include/MeshObject/Face.hpp
@@ -34,6 +34,7 @@ public:
     const Eigen::Vector3d& get_center() const;
     const std::unordered_set<std::shared_ptr<Vertex>, MeshObjectHash>& get_vertices() const;
     const std::unordered_set<std::shared_ptr<InteriorPoint>, MeshObjectHash>& get_interior_points() const;
+    const std::unordered_set<std::shared_ptr<Edge>, MeshObjectHash>& get_edges() const;
     const std::shared_ptr<Vertex>& get_vertex(int index) const;
     const std::shared_ptr<Vertex>& get_first_vertex() const;
     const std::shared_ptr<Surface>& get_surface() const;
@@ -58,6 +59,9 @@ public:
     void disconnect(const std::shared_ptr<Surface>& surface);
     void disconnect(const std::shared_ptr<InteriorPoint>& interior_point);
     void disconnect(const std::shared_ptr<Face>& sibling_face);
+
+    bool is_connected_to_boundary_edges(std::unordered_set<std::shared_ptr<Face>, MeshObjectHash>& all_connected_faces, std::unordered_set<std::shared_ptr<Edge>, MeshObjectHash>& all_connected_edges) const;
+    bool is_non_manifold() const;
 
     void swap(const std::shared_ptr<Vertex>& vertex1, const std::shared_ptr<Vertex>& vertex2);
 

--- a/include/MeshObject/InteractiveViewer.hpp
+++ b/include/MeshObject/InteractiveViewer.hpp
@@ -17,6 +17,7 @@ private:
 
     // objects
     Application<PointT>& app_;
+    std::shared_ptr<Storage> storage_;
     pcl::visualization::PCLVisualizer::Ptr viewer_;
 
     // settings

--- a/include/MeshObject/Storage.hpp
+++ b/include/MeshObject/Storage.hpp
@@ -70,6 +70,7 @@ public: // to user
     void cleanup_surfaces();
     void remove_non_manifold_edges();
     void remove_non_manifold_vertices();
+    void remove_non_manifold_faces();
     void update_radius();
 
     void add_points_in_add_searchable_vertex_queue();

--- a/include/MeshObject/Storage.hpp
+++ b/include/MeshObject/Storage.hpp
@@ -70,6 +70,7 @@ public: // to user
     void cleanup_surfaces();
     void remove_non_manifold_edges();
     void remove_non_manifold_vertices();
+    void update_radius();
 
     void add_points_in_add_searchable_vertex_queue();
     void add_or_remove_vertices_from_rrs_tree();

--- a/include/MeshObject/Storage.hpp
+++ b/include/MeshObject/Storage.hpp
@@ -67,6 +67,8 @@ public: // to user
     unsigned int get_abort_queue_size();
     void clear_queues();
 
+    void cleanup_surfaces();
+
     void add_points_in_add_searchable_vertex_queue();
     void add_or_remove_vertices_from_rrs_tree();
     void add_or_remove_faces_from_bvh_tree();

--- a/include/MeshObject/Storage.hpp
+++ b/include/MeshObject/Storage.hpp
@@ -69,6 +69,7 @@ public: // to user
 
     void cleanup_surfaces();
     void remove_non_manifold_edges();
+    void remove_non_manifold_vertices();
 
     void add_points_in_add_searchable_vertex_queue();
     void add_or_remove_vertices_from_rrs_tree();

--- a/include/MeshObject/Storage.hpp
+++ b/include/MeshObject/Storage.hpp
@@ -68,6 +68,7 @@ public: // to user
     void clear_queues();
 
     void cleanup_surfaces();
+    void remove_non_manifold_edges();
 
     void add_points_in_add_searchable_vertex_queue();
     void add_or_remove_vertices_from_rrs_tree();

--- a/include/MeshObject/Surface.hpp
+++ b/include/MeshObject/Surface.hpp
@@ -89,7 +89,8 @@ public:
     void disconnect(const std::shared_ptr<InteriorPoint>& interior_point);
 
     std::unordered_set<std::shared_ptr<Vertex>, MeshObjectHash> get_boundary_vertices();
-    void try_close_holes();
+    bool try_close_holes_repeatedly();
+    bool try_close_holes();
 
     void remove_non_manifold_edges();
 

--- a/include/MeshObject/Surface.hpp
+++ b/include/MeshObject/Surface.hpp
@@ -88,6 +88,9 @@ public:
     void disconnect(const std::shared_ptr<Face>& face);
     void disconnect(const std::shared_ptr<InteriorPoint>& interior_point);
 
+    std::unordered_set<std::shared_ptr<Vertex>, MeshObjectHash> get_boundary_vertices();
+    void try_close_holes();
+
     void swap(const std::shared_ptr<Vertex>& vertex1, const std::shared_ptr<Vertex>& vertex2);
     void pause_normal_std_update();
     void resume_normal_std_update();

--- a/include/MeshObject/Surface.hpp
+++ b/include/MeshObject/Surface.hpp
@@ -91,6 +91,8 @@ public:
     std::unordered_set<std::shared_ptr<Vertex>, MeshObjectHash> get_boundary_vertices();
     void try_close_holes();
 
+    void remove_non_manifold_edges();
+
     void swap(const std::shared_ptr<Vertex>& vertex1, const std::shared_ptr<Vertex>& vertex2);
     void pause_normal_std_update();
     void resume_normal_std_update();

--- a/include/MeshObject/Surface.hpp
+++ b/include/MeshObject/Surface.hpp
@@ -97,6 +97,7 @@ public:
 
     void set_random_color();
 
+    bool tree_intersect_edge(const std::shared_ptr<Vertex>& vertex0, const std::shared_ptr<Vertex>& vertex1);
     bool connect_by_edges_and_faces(const std::shared_ptr<Vertex>& vertex, const std::unordered_set<std::shared_ptr<Vertex>, MeshObjectHash>& all_nearby_vertices);
 
     void compute_surface_position_std_in_normal_direction();

--- a/include/MeshObject/Vertex.hpp
+++ b/include/MeshObject/Vertex.hpp
@@ -84,6 +84,10 @@ public:
     bool check_connected_by_face(const std::shared_ptr<Vertex>& vertex0, const std::shared_ptr<Vertex>& vertex1);
     bool try_close_holes_repeatedly();
     bool try_close_holes();
+    void remove_all_edges();
+
+    // can self destruct flag
+    void set_can_self_destruct(bool can_self_destruct);
 
     // non manifold
     bool is_non_manifold() const;

--- a/include/MeshObject/Vertex.hpp
+++ b/include/MeshObject/Vertex.hpp
@@ -78,12 +78,15 @@ public:
     void disconnect(const std::shared_ptr<Surface>& surface);
     void disconnect(const std::shared_ptr<Vertex>& sibling_vertex);
 
-    std::unordered_set<std::shared_ptr<Edge>, MeshObjectHash> get_connected_boundary_edges();
+    std::unordered_set<std::shared_ptr<Edge>, MeshObjectHash> get_connected_boundary_edges() const;
     std::unordered_set<std::shared_ptr<Vertex>, MeshObjectHash> get_connected_boundary_vertices();
     bool check_connected_by_edge(const std::shared_ptr<Vertex>& vertex);
     bool check_connected_by_face(const std::shared_ptr<Vertex>& vertex0, const std::shared_ptr<Vertex>& vertex1);
     bool try_close_holes_repeatedly();
     bool try_close_holes();
+
+    // non manifold
+    bool is_non_manifold() const;
 
     // point - nearby vertex
     void add_nearby_vertex(const std::shared_ptr<Vertex>& rrs_vertex);

--- a/include/MeshObject/Vertex.hpp
+++ b/include/MeshObject/Vertex.hpp
@@ -85,6 +85,7 @@ public:
     bool check_connected_by_edge(const std::shared_ptr<Vertex>& vertex);
     bool check_connected_by_face(const std::shared_ptr<Vertex>& vertex0, const std::shared_ptr<Vertex>& vertex1);
     bool try_close_holes_repeatedly();
+    bool try_close_holes_between_self_and(std::shared_ptr<Vertex>& vertex0, std::shared_ptr<Vertex>& vertex1);
     bool try_close_holes();
     void remove_all_edges();
 

--- a/include/MeshObject/Vertex.hpp
+++ b/include/MeshObject/Vertex.hpp
@@ -52,6 +52,8 @@ public:
 
     double& get_projected_uncertainty();
 
+    const std::shared_ptr<Edge>& get_edge(const std::shared_ptr<Vertex>& vertex) const;
+
     // void try_merge_surfaces();
 
     const Eigen::Vector3d& buffer_compute_projected_position(const std::shared_ptr<Surface> surface);

--- a/include/MeshObject/Vertex.hpp
+++ b/include/MeshObject/Vertex.hpp
@@ -82,6 +82,7 @@ public:
     std::unordered_set<std::shared_ptr<Vertex>, MeshObjectHash> get_connected_boundary_vertices();
     bool check_connected_by_edge(const std::shared_ptr<Vertex>& vertex);
     bool check_connected_by_face(const std::shared_ptr<Vertex>& vertex0, const std::shared_ptr<Vertex>& vertex1);
+    bool try_close_holes();
 
     // point - nearby vertex
     void add_nearby_vertex(const std::shared_ptr<Vertex>& rrs_vertex);

--- a/include/MeshObject/Vertex.hpp
+++ b/include/MeshObject/Vertex.hpp
@@ -78,6 +78,11 @@ public:
     void disconnect(const std::shared_ptr<Surface>& surface);
     void disconnect(const std::shared_ptr<Vertex>& sibling_vertex);
 
+    std::unordered_set<std::shared_ptr<Edge>, MeshObjectHash> get_connected_boundary_edges();
+    std::unordered_set<std::shared_ptr<Vertex>, MeshObjectHash> get_connected_boundary_vertices();
+    bool check_connected_by_edge(const std::shared_ptr<Vertex>& vertex);
+    bool check_connected_by_face(const std::shared_ptr<Vertex>& vertex0, const std::shared_ptr<Vertex>& vertex1);
+
     // point - nearby vertex
     void add_nearby_vertex(const std::shared_ptr<Vertex>& rrs_vertex);
     void delete_nearby_vertex(const std::shared_ptr<Vertex>& rrs_vertex);

--- a/include/MeshObject/Vertex.hpp
+++ b/include/MeshObject/Vertex.hpp
@@ -82,6 +82,7 @@ public:
     std::unordered_set<std::shared_ptr<Vertex>, MeshObjectHash> get_connected_boundary_vertices();
     bool check_connected_by_edge(const std::shared_ptr<Vertex>& vertex);
     bool check_connected_by_face(const std::shared_ptr<Vertex>& vertex0, const std::shared_ptr<Vertex>& vertex1);
+    bool try_close_holes_repeatedly();
     bool try_close_holes();
 
     // point - nearby vertex

--- a/src/MeshObject/Application.cpp
+++ b/src/MeshObject/Application.cpp
@@ -923,6 +923,12 @@ void Application<PointT>::rebuild_tree()
 }
 
 template <typename PointT>
+void Application<PointT>::cleanup_surfaces()
+{
+    storage_->cleanup_surfaces();
+}
+
+template <typename PointT>
 pcl::PointCloud<pcl::PointXYZRGB>::Ptr Application<PointT>::compute_generic_point_pointcloud()
 {
     pcl::PointCloud<pcl::PointXYZRGB>::Ptr cloud(new pcl::PointCloud<pcl::PointXYZRGB>);

--- a/src/MeshObject/Application.cpp
+++ b/src/MeshObject/Application.cpp
@@ -941,6 +941,12 @@ void Application<PointT>::remove_non_manifold_vertices()
 }
 
 template <typename PointT>
+void Application<PointT>::update_radius()
+{
+    storage_->update_radius();
+}
+
+template <typename PointT>
 pcl::PointCloud<pcl::PointXYZRGB>::Ptr Application<PointT>::compute_generic_point_pointcloud()
 {
     pcl::PointCloud<pcl::PointXYZRGB>::Ptr cloud(new pcl::PointCloud<pcl::PointXYZRGB>);

--- a/src/MeshObject/Application.cpp
+++ b/src/MeshObject/Application.cpp
@@ -923,27 +923,9 @@ void Application<PointT>::rebuild_tree()
 }
 
 template <typename PointT>
-void Application<PointT>::cleanup_surfaces()
+std::shared_ptr<Storage> Application<PointT>::get_storage()
 {
-    storage_->cleanup_surfaces();
-}
-
-template <typename PointT>
-void Application<PointT>::remove_non_manifold_edges()
-{
-    storage_->remove_non_manifold_edges();
-}
-
-template <typename PointT>
-void Application<PointT>::remove_non_manifold_vertices()
-{
-    storage_->remove_non_manifold_vertices();
-}
-
-template <typename PointT>
-void Application<PointT>::update_radius()
-{
-    storage_->update_radius();
+    return storage_;
 }
 
 template <typename PointT>

--- a/src/MeshObject/Application.cpp
+++ b/src/MeshObject/Application.cpp
@@ -929,6 +929,12 @@ void Application<PointT>::cleanup_surfaces()
 }
 
 template <typename PointT>
+void Application<PointT>::remove_non_manifold_edges()
+{
+    storage_->remove_non_manifold_edges();
+}
+
+template <typename PointT>
 pcl::PointCloud<pcl::PointXYZRGB>::Ptr Application<PointT>::compute_generic_point_pointcloud()
 {
     pcl::PointCloud<pcl::PointXYZRGB>::Ptr cloud(new pcl::PointCloud<pcl::PointXYZRGB>);

--- a/src/MeshObject/Application.cpp
+++ b/src/MeshObject/Application.cpp
@@ -935,6 +935,12 @@ void Application<PointT>::remove_non_manifold_edges()
 }
 
 template <typename PointT>
+void Application<PointT>::remove_non_manifold_vertices()
+{
+    storage_->remove_non_manifold_vertices();
+}
+
+template <typename PointT>
 pcl::PointCloud<pcl::PointXYZRGB>::Ptr Application<PointT>::compute_generic_point_pointcloud()
 {
     pcl::PointCloud<pcl::PointXYZRGB>::Ptr cloud(new pcl::PointCloud<pcl::PointXYZRGB>);

--- a/src/MeshObject/Edge.cpp
+++ b/src/MeshObject/Edge.cpp
@@ -98,6 +98,10 @@ void Edge::connect(const std::shared_ptr<Face>& face)
 
     // connect
     bool inserted = faces_.insert(face).second;
+    if (inserted)
+    {
+        if (faces_.size() > 2) throw std::runtime_error("Edge connected to more than 2 faces.");
+    }
     if (inserted) face->connect(shared_from_this());
 
     // update boundary state

--- a/src/MeshObject/Edge.cpp
+++ b/src/MeshObject/Edge.cpp
@@ -211,6 +211,24 @@ void Edge::disconnect(const std::shared_ptr<Edge>& sibling_edge)
     if (erased) sibling_edge->disconnect(shared_from_this());
 }
 
+bool Edge::is_connected_to_boundary_edges(std::unordered_set<std::shared_ptr<Face>, MeshObjectHash>& all_connected_faces, std::unordered_set<std::shared_ptr<Edge>, MeshObjectHash>& all_connected_edges) const
+{
+    // check for each face
+    for (const std::shared_ptr<Face>& face : get_faces())
+    {
+        // add to visited faces
+        const bool inserted = all_connected_faces.insert(face).second;
+
+        // skip if face is already visited
+        if (!inserted) continue;
+
+        // return true if face is boundary
+        if (face->is_connected_to_boundary_edges(all_connected_faces, all_connected_edges)) return true;
+    }
+
+    return false;
+}
+
 void Edge::swap(const std::shared_ptr<Vertex>& vertex1, const std::shared_ptr<Vertex>& vertex2)
 {
     // make sure the position of vertex 1 and 2 are identical, otherwise need to update BVH which is not yet implemented

--- a/src/MeshObject/Edge.cpp
+++ b/src/MeshObject/Edge.cpp
@@ -375,6 +375,12 @@ void Edge::remove_searchable_state()
     }
 }
 
+bool Edge::is_non_manifold() const
+{
+    // non manifold if connected to more than 2 faces
+    return faces_.size() > 2;
+}
+
 const std::shared_ptr<Surface>& Edge::get_surface() const
 {
     return surface_;

--- a/src/MeshObject/Edge.cpp
+++ b/src/MeshObject/Edge.cpp
@@ -445,6 +445,9 @@ const double& Edge::get_length() const
 
 bool Edge::intersects_edge(const std::shared_ptr<Surface>& surface, const std::shared_ptr<Vertex>& vertex0, const std::shared_ptr<Vertex>& vertex1)
 {
+    // skip if deleting
+    if (is_deleting()) return false;
+
     // skip if vertices are connected
     if (has_vertex(vertex0) || has_vertex(vertex1)) return false;
 

--- a/src/MeshObject/Edge.cpp
+++ b/src/MeshObject/Edge.cpp
@@ -211,6 +211,11 @@ void Edge::disconnect(const std::shared_ptr<Edge>& sibling_edge)
     if (erased) sibling_edge->disconnect(shared_from_this());
 }
 
+void Edge::set_can_self_destruct(bool can_self_destruct)
+{
+    can_self_destruct_ = can_self_destruct;
+}
+
 bool Edge::is_connected_to_boundary_edges(std::unordered_set<std::shared_ptr<Face>, MeshObjectHash>& all_connected_faces, std::unordered_set<std::shared_ptr<Edge>, MeshObjectHash>& all_connected_edges) const
 {
     // check for each face

--- a/src/MeshObject/Face.cpp
+++ b/src/MeshObject/Face.cpp
@@ -200,6 +200,11 @@ const std::unordered_set<std::shared_ptr<InteriorPoint>, MeshObjectHash>& Face::
     return interior_points_;
 }
 
+const std::unordered_set<std::shared_ptr<Edge>, MeshObjectHash>& Face::get_edges() const
+{
+    return edges_;
+}
+
 const std::shared_ptr<Vertex>& Face::get_vertex(int index) const
 {
     if (index < 0 || index > 2) throw std::runtime_error("Invalid index for vertex.");
@@ -456,6 +461,35 @@ void Face::disconnect(const std::shared_ptr<Face>& sibling_face)
     // delete
     bool erased = sibling_faces_.erase(sibling_face);
     if (erased) sibling_face->disconnect(shared_from_this());
+}
+
+bool Face::is_connected_to_boundary_edges(std::unordered_set<std::shared_ptr<Face>, MeshObjectHash>& all_connected_faces, std::unordered_set<std::shared_ptr<Edge>, MeshObjectHash>& all_connected_edges) const
+{
+    // check for each edge
+    for (const std::shared_ptr<Edge>& edge : get_edges())
+    {
+        // add to visited edges
+        const bool inserted = all_connected_edges.insert(edge).second;
+
+        // skip if edge is already visited
+        if (!inserted) continue;
+
+        // return true if edge is boundary
+        if (edge->is_boundary()) return true;
+        
+        // else, recursively check connected faces
+        if (edge->is_connected_to_boundary_edges(all_connected_faces, all_connected_edges)) return true;        
+    }
+
+    return false;
+}
+
+bool Face::is_non_manifold() const
+{
+    std::unordered_set<std::shared_ptr<Face>, MeshObjectHash> all_connected_faces;
+    std::unordered_set<std::shared_ptr<Edge>, MeshObjectHash> all_connected_edges;
+
+    return !is_connected_to_boundary_edges(all_connected_faces, all_connected_edges);
 }
 
 void Face::swap(const std::shared_ptr<Vertex>& vertex1, const std::shared_ptr<Vertex>& vertex2)

--- a/src/MeshObject/InteractiveViewer.cpp
+++ b/src/MeshObject/InteractiveViewer.cpp
@@ -425,11 +425,11 @@ void InteractiveViewer<PointT>::keyboard_callback(const pcl::visualization::Keyb
     }
     if (event.getKeySym() == "b" && event.keyDown())
     {
-        app_.refine_surfaces();
+        app_.cleanup_surfaces();
         update_display();
 
         // log
-        std::cout << "refined surfaces" << std::endl;
+        std::cout << "cleanup surfaces" << std::endl;
     }
     if (event.getKeySym() == "k" && event.keyDown())
     {

--- a/src/MeshObject/InteractiveViewer.cpp
+++ b/src/MeshObject/InteractiveViewer.cpp
@@ -2,6 +2,7 @@
 #include "MeshObject/Vertex.hpp"
 #include "MeshObject/Edge.hpp"
 #include "MeshObject/Face.hpp"
+#include "MeshObject/Storage.hpp"
 #include <unordered_set>
 #include <pcl/io/ply_io.h>
 
@@ -17,6 +18,8 @@ InteractiveViewer<PointT>::InteractiveViewer(Application<PointT>& app)
     app_(app),
     viewer_(new pcl::visualization::PCLVisualizer ("3D Viewer"))
 {   
+    storage_ = app.get_storage();
+    
     viewer_->getRenderWindow()->GlobalWarningDisplayOff(); // Add This Line
     if (settings_.flip_color) 
     {
@@ -236,7 +239,7 @@ void InteractiveViewer<PointT>::keyboard_callback(const pcl::visualization::Keyb
     if (event.getKeySym() == "KP_Next" && event.keyDown())
     {
         settings_.color_mode = ColorMode::RADIUS;
-        app_.update_radius();
+        storage_->update_radius();
 
         update_display();
 
@@ -427,15 +430,15 @@ void InteractiveViewer<PointT>::keyboard_callback(const pcl::visualization::Keyb
     // }
     if (event.getKeySym() == "b" && event.keyDown())
     {
-        app_.cleanup_surfaces();
+        storage_->cleanup_surfaces();
         update_display();
 
         // log
-        std::cout << "cleanup surfaces" << std::endl;
+        std::cout << "close holes" << std::endl;
     }
     if (event.getKeySym() == "n" && event.keyDown())
     {
-        app_.remove_non_manifold_edges();
+        storage_->remove_non_manifold_edges();
         update_display();
 
         // log
@@ -443,7 +446,7 @@ void InteractiveViewer<PointT>::keyboard_callback(const pcl::visualization::Keyb
     }
     if (event.getKeySym() == "m" && event.keyDown())
     {
-        app_.remove_non_manifold_vertices();
+        storage_->remove_non_manifold_vertices();
         update_display();
 
         // log

--- a/src/MeshObject/InteractiveViewer.cpp
+++ b/src/MeshObject/InteractiveViewer.cpp
@@ -454,12 +454,11 @@ void InteractiveViewer<PointT>::keyboard_callback(const pcl::visualization::Keyb
     }
     if (event.getKeySym() == "k" && event.keyDown())
     {
-        // toggle generic points
-        settings_.show_generic_points = !settings_.show_generic_points;
+        storage_->remove_non_manifold_faces();
         update_display();
 
         // log
-        std::cout << "show_generic_points: " << settings_.show_generic_points << std::endl;
+        std::cout << "remove non manifold faces" << std::endl;
     }
     if (event.getKeySym() == "l" && event.keyDown())
     {

--- a/src/MeshObject/InteractiveViewer.cpp
+++ b/src/MeshObject/InteractiveViewer.cpp
@@ -431,6 +431,14 @@ void InteractiveViewer<PointT>::keyboard_callback(const pcl::visualization::Keyb
         // log
         std::cout << "cleanup surfaces" << std::endl;
     }
+    if (event.getKeySym() == "n" && event.keyDown())
+    {
+        app_.remove_non_manifold_edges();
+        update_display();
+
+        // log
+        std::cout << "remove non manifold edges" << std::endl;
+    }
     if (event.getKeySym() == "k" && event.keyDown())
     {
         // toggle generic points

--- a/src/MeshObject/InteractiveViewer.cpp
+++ b/src/MeshObject/InteractiveViewer.cpp
@@ -415,14 +415,14 @@ void InteractiveViewer<PointT>::keyboard_callback(const pcl::visualization::Keyb
         // log
         std::cout << "show_wireframe: " << settings_.show_wireframe << std::endl;
     }
-    if (event.getKeySym() == "m" && event.keyDown())
-    {
-        settings_.show_sphere = !settings_.show_sphere;
-        update_display();
+    // if (event.getKeySym() == "m" && event.keyDown())
+    // {
+    //     settings_.show_sphere = !settings_.show_sphere;
+    //     update_display();
 
-        // log
-        std::cout << "show_sphere: " << settings_.show_sphere << std::endl;
-    }
+    //     // log
+    //     std::cout << "show_sphere: " << settings_.show_sphere << std::endl;
+    // }
     if (event.getKeySym() == "b" && event.keyDown())
     {
         app_.cleanup_surfaces();
@@ -438,6 +438,14 @@ void InteractiveViewer<PointT>::keyboard_callback(const pcl::visualization::Keyb
 
         // log
         std::cout << "remove non manifold edges" << std::endl;
+    }
+    if (event.getKeySym() == "m" && event.keyDown())
+    {
+        app_.remove_non_manifold_vertices();
+        update_display();
+
+        // log
+        std::cout << "remove non manifold vertices" << std::endl;
     }
     if (event.getKeySym() == "k" && event.keyDown())
     {

--- a/src/MeshObject/InteractiveViewer.cpp
+++ b/src/MeshObject/InteractiveViewer.cpp
@@ -236,6 +236,8 @@ void InteractiveViewer<PointT>::keyboard_callback(const pcl::visualization::Keyb
     if (event.getKeySym() == "KP_Next" && event.keyDown())
     {
         settings_.color_mode = ColorMode::RADIUS;
+        app_.update_radius();
+
         update_display();
 
         // log

--- a/src/MeshObject/Settings.cpp
+++ b/src/MeshObject/Settings.cpp
@@ -34,6 +34,10 @@ Settings::Settings()
         "/home/jiahao/datasets/2024-11-19_14-05-08_rec013/slam_clouds/",
         "/home/jiahao/datasets/2024-11-19_14-05-08_rec013/slam_pose_graph.slam"
     );
+    dataset_map["abingdon"] = std::make_pair(
+        "/home/jiahao/datasets/abingdon logs/2024-12-03_10-25-53_rec001_rad301_run2/slam_clouds/",
+        "/home/jiahao/datasets/abingdon logs/2024-12-03_10-25-53_rec001_rad301_run2/slam_pose_graph.slam"
+    );
 
     std::string dataset = "nottinghill";
     data_loader_settings.pcd_file_folder = dataset_map[dataset].first;

--- a/src/MeshObject/Settings.cpp
+++ b/src/MeshObject/Settings.cpp
@@ -67,7 +67,7 @@ Settings::Settings()
     shuffle_pointcloud = true;
     use_radius_value = true;
     pointcloud_fraction = 1;
-    radius_value = 3;
+    radius_value = 1;
     extra_radius = 0.1;
     duplicated_point_distance_threshold = 0.0; // if two points are closer than this distance, they are considered the same point
 

--- a/src/MeshObject/Storage.cpp
+++ b/src/MeshObject/Storage.cpp
@@ -706,6 +706,21 @@ void Storage::remove_non_manifold_vertices()
     }
 }
 
+void Storage::update_radius()
+{
+    // make copy of vertices
+    std::vector<std::shared_ptr<Vertex>> vertices_copy(vertices_.begin(), vertices_.end());
+
+    for (const std::shared_ptr<Vertex>& vertex : vertices_copy)
+    {
+        // skip if vertex is expired
+        if (vertex->is_expired()) continue;
+
+        // try update radius
+        vertex->try_update_radius();
+    }
+}
+
 void Storage::add_searchable_vertex(const std::shared_ptr<Vertex>& vertex)
 {
     // add to a queue that will be processed once all locks are released

--- a/src/MeshObject/Storage.cpp
+++ b/src/MeshObject/Storage.cpp
@@ -680,6 +680,19 @@ void Storage::cleanup_surfaces()
     }
 }
 
+void Storage::remove_non_manifold_edges()
+{
+    // make copy of edges
+    std::vector<std::shared_ptr<Edge>> edges_copy(edges_.begin(), edges_.end());
+
+    // for each edge
+    for (const std::shared_ptr<Edge>& edge : edges_copy)
+    {
+        // delete if edge is non-manifold
+        if (edge->is_non_manifold()) delete_edge(edge);
+    }
+}
+
 void Storage::add_searchable_vertex(const std::shared_ptr<Vertex>& vertex)
 {
     // add to a queue that will be processed once all locks are released

--- a/src/MeshObject/Storage.cpp
+++ b/src/MeshObject/Storage.cpp
@@ -625,6 +625,51 @@ void Storage::clear_queues()
     }
 }
 
+void Storage::cleanup_surfaces()
+{
+    // make copy of surfaces
+    std::vector<std::shared_ptr<Surface>> surfaces_copy(surfaces_.begin(), surfaces_.end());
+
+    // for each surface
+    for (const std::shared_ptr<Surface>& surface : surfaces_copy)
+    {
+        // delete if surface is seed
+        if (surface->get_total_point_size() < settings_.fit_plane_threshold) 
+        {
+            delete_surface(surface);
+            continue;
+        }
+
+        // delete if surface have no boudary point
+        std::unordered_set<std::shared_ptr<Vertex>, MeshObjectHash> vertices = surface->get_vertices();
+        bool has_boundary = false;
+        for (const std::shared_ptr<Vertex>& vertex : vertices)
+        {
+            if (vertex->is_boundary())
+            {
+                has_boundary = true;
+                break;
+            }
+        }
+        if (!has_boundary) 
+        {
+            delete_surface(surface);
+            continue;
+        }
+
+        // delete if number of face is less than 3
+        if (surface->get_faces().size() < 3) 
+        {
+            delete_surface(surface);
+            continue;
+        }
+
+
+        // what makes a surface bad?
+        
+    }
+}
+
 void Storage::add_searchable_vertex(const std::shared_ptr<Vertex>& vertex)
 {
     // add to a queue that will be processed once all locks are released

--- a/src/MeshObject/Storage.cpp
+++ b/src/MeshObject/Storage.cpp
@@ -676,7 +676,7 @@ void Storage::cleanup_surfaces()
         if (surface->is_expired()) continue;
 
         // try closing holes
-        surface->try_close_holes();
+        surface->try_close_holes_repeatedly();
     }
 }
 

--- a/src/MeshObject/Storage.cpp
+++ b/src/MeshObject/Storage.cpp
@@ -668,6 +668,16 @@ void Storage::cleanup_surfaces()
         // what makes a surface bad?
         
     }
+
+    // after cleaning up, try closing the holes in each surface
+    for (const std::shared_ptr<Surface>& surface : surfaces_copy)
+    {
+        // skip if expired
+        if (surface->is_expired()) continue;
+
+        // try closing holes
+        surface->try_close_holes();
+    }
 }
 
 void Storage::add_searchable_vertex(const std::shared_ptr<Vertex>& vertex)

--- a/src/MeshObject/Storage.cpp
+++ b/src/MeshObject/Storage.cpp
@@ -693,6 +693,28 @@ void Storage::remove_non_manifold_edges()
     }
 }
 
+void Storage::remove_non_manifold_faces()
+{
+    // initialize
+    std::vector<std::shared_ptr<Face>> non_manifold_faces;
+    
+    // collect all non manifold faces
+    for (const std::shared_ptr<Face>& face : faces_)
+    {
+        if (face->is_non_manifold()) non_manifold_faces.push_back(face);
+    }
+
+    // delete all non manifold faces
+    for (const std::shared_ptr<Face>& face : non_manifold_faces)
+    {
+        // skip if face is expired
+        if (face->is_expired()) continue;
+
+        // delete face
+        delete_face(face);
+    }
+}
+
 void Storage::remove_non_manifold_vertices()
 {
     // make copy of vertices

--- a/src/MeshObject/Storage.cpp
+++ b/src/MeshObject/Storage.cpp
@@ -693,6 +693,19 @@ void Storage::remove_non_manifold_edges()
     }
 }
 
+void Storage::remove_non_manifold_vertices()
+{
+    // make copy of vertices
+    std::vector<std::shared_ptr<Vertex>> vertices_copy(vertices_.begin(), vertices_.end());
+
+    // for each vertex
+    for (const std::shared_ptr<Vertex>& vertex : vertices_copy)
+    {
+        // delete if vertex is non-manifold
+        if (vertex->is_non_manifold()) delete_vertex(vertex);
+    }
+}
+
 void Storage::add_searchable_vertex(const std::shared_ptr<Vertex>& vertex)
 {
     // add to a queue that will be processed once all locks are released

--- a/src/MeshObject/Surface.cpp
+++ b/src/MeshObject/Surface.cpp
@@ -731,6 +731,9 @@ bool Surface::connect_by_edges_and_faces(const std::shared_ptr<Vertex>& vertex, 
         }
     }
 
+    // try close holes
+    vertex->try_close_holes_repeatedly();
+    
     // false if new vertex don't have edges
     if (vertex->get_edges().empty()) return false;
 

--- a/src/MeshObject/Surface.cpp
+++ b/src/MeshObject/Surface.cpp
@@ -670,7 +670,6 @@ bool Surface::connect_by_edges_and_faces(const std::shared_ptr<Vertex>& vertex, 
     }
 
     // create edges
-    std::unordered_set<std::shared_ptr<Vertex>, MeshObjectHash> used_vertices;
     std::unordered_set<std::shared_ptr<Edge>, MeshObjectHash> new_edges;
     for (const auto& nearby_vertex : nearby_vertices)
     {
@@ -686,7 +685,6 @@ bool Surface::connect_by_edges_and_faces(const std::shared_ptr<Vertex>& vertex, 
         connect(new_edge);
 
         // store used vertices and new edges
-        used_vertices.insert(nearby_vertex);
         new_edges.insert(new_edge);
 
         // update flag
@@ -695,20 +693,24 @@ bool Surface::connect_by_edges_and_faces(const std::shared_ptr<Vertex>& vertex, 
 
     // create faces
     std::unordered_set<std::shared_ptr<Face>, MeshObjectHash> new_faces;
-    for (const std::shared_ptr<Vertex>& nearby_vertex0 : used_vertices)
+    for (const auto& edge0 : new_edges)
     {
-        for (const std::shared_ptr<Vertex>& nearby_vertex1 : used_vertices)
+        std::shared_ptr<Vertex> vertex0 = edge0->get_vertex(0) != vertex ? edge0->get_vertex(0) : edge0->get_vertex(1);
+
+        for (const auto& edge1 : new_edges)
         {
+            std::shared_ptr<Vertex> vertex1 = edge1->get_vertex(0) != vertex ? edge1->get_vertex(0) : edge1->get_vertex(1);
+
             // skip if repeated
-            if (nearby_vertex1 <= nearby_vertex0) continue;
+            if (vertex0 <= vertex1) continue;
 
             // skip if edge does not exist between the two vertices
             bool edge_exist = false;
             std::shared_ptr<Edge> existing_edge;
-            for (const std::shared_ptr<Edge>& edge : nearby_vertex0->get_edges())
+            for (const std::shared_ptr<Edge>& edge : vertex0->get_edges())
             {
                 if (edge->get_surface() != shared_from_this()) continue;
-                if (edge->has_vertex(nearby_vertex1))
+                if (edge->has_vertex(vertex1))
                 {
                     edge_exist = true;
                     existing_edge = edge;
@@ -720,27 +722,8 @@ bool Surface::connect_by_edges_and_faces(const std::shared_ptr<Vertex>& vertex, 
             // skip if edge is not boundary
             if (!existing_edge->is_boundary()) continue;
 
-            // skip if face contains nearby vertices
-            // get surface coordinate of the vertices
-            Eigen::Vector2d surface_coordinate0 = vertex->get_surface_coordinate(shared_from_this());
-            Eigen::Vector2d surface_coordinate1 = nearby_vertex0->get_surface_coordinate(shared_from_this());
-            Eigen::Vector2d surface_coordinate2 = nearby_vertex1->get_surface_coordinate(shared_from_this());
-            // check if the triangle formed by the vertices contains any other nearby_vertices
-            bool triangle_contains_nearby_vertices = false;
-            for (const std::shared_ptr<Vertex>& nearby_vertex : nearby_vertices)
-            {
-                if (nearby_vertex == nearby_vertex0 || nearby_vertex == nearby_vertex1) continue;
-                Eigen::Vector2d surface_coordinate = nearby_vertex->get_surface_coordinate(shared_from_this());
-                if (is_point_in_triangle(surface_coordinate0, surface_coordinate1, surface_coordinate2, surface_coordinate))
-                {
-                    triangle_contains_nearby_vertices = true;
-                    break;
-                }
-            }
-            if (triangle_contains_nearby_vertices) continue;
-
             // create face
-            std::shared_ptr<Face> new_face = storage_->add_face(shared_from_this(), vertex, nearby_vertex0, nearby_vertex1);
+            std::shared_ptr<Face> new_face = storage_->add_face(shared_from_this(), vertex, vertex0, vertex1);
             new_faces.insert(new_face);
         }
     }

--- a/src/MeshObject/Surface.cpp
+++ b/src/MeshObject/Surface.cpp
@@ -970,16 +970,37 @@ std::unordered_set<std::shared_ptr<Vertex>, MeshObjectHash> Surface::get_boundar
     return boundary_vertices;
 }
 
-void Surface::try_close_holes()
+bool Surface::try_close_holes_repeatedly()
 {
+    // initialize
+    bool changed = false;
+
+    // try close holes repeatedly
+    while (try_close_holes()) 
+    {
+        changed = true;
+    }
+
+    // return
+    return changed;
+}
+
+bool Surface::try_close_holes()
+{
+    // initialize
+    bool changed = false;
+
     // boundary vertices
     std::unordered_set<std::shared_ptr<Vertex>, MeshObjectHash> boundary_vertices = get_boundary_vertices();
 
     // for each boundary vertex
     for (const auto& vertex : boundary_vertices)
     {
-        vertex->try_close_holes();
+        if (vertex->try_close_holes_repeatedly()) changed = true;
     }
+
+    // return
+    return changed;
 }
 
 void Surface::remove_non_manifold_edges()

--- a/src/MeshObject/Surface.cpp
+++ b/src/MeshObject/Surface.cpp
@@ -733,6 +733,9 @@ bool Surface::connect_by_edges_and_faces(const std::shared_ptr<Vertex>& vertex, 
 
     // try close holes
     vertex->try_close_holes_repeatedly();
+
+    // false if after try close holes, the vertex still have more than two boundary edges
+    if (vertex->get_connected_boundary_edges().size() > 2) return false;
     
     // false if new vertex don't have edges
     if (vertex->get_edges().empty()) return false;

--- a/src/MeshObject/Surface.cpp
+++ b/src/MeshObject/Surface.cpp
@@ -731,9 +731,23 @@ bool Surface::connect_by_edges_and_faces(const std::shared_ptr<Vertex>& vertex, 
         }
     }
 
-    // if new vertex have edges, return true, else return false
-    if (vertex->get_edges().size() > 0) return true;
-    else return false;
+    // false if new vertex don't have edges
+    if (new_edges.size() == 0) return false;
+    
+    // false if surface have no boundary edges
+    bool has_boundary_edges = false;
+    for (const auto& edge : edges_)
+    {
+        if (edge->is_boundary()) 
+        {
+            has_boundary_edges = true;
+            break;
+        }
+    }
+    if (!has_boundary_edges) return false;
+
+    // else
+    return true;
 }
 
 void Surface::compute_surface_position_std_in_normal_direction()

--- a/src/MeshObject/Surface.cpp
+++ b/src/MeshObject/Surface.cpp
@@ -950,6 +950,68 @@ void Surface::disconnect(const std::shared_ptr<InteriorPoint>& interior_point)
     }
 }
 
+std::unordered_set<std::shared_ptr<Vertex>, MeshObjectHash> Surface::get_boundary_vertices()
+{
+    // initialize
+    std::unordered_set<std::shared_ptr<Vertex>, MeshObjectHash> boundary_vertices;
+
+    // get boundary vertices
+    for (const auto& vertex : vertices_)
+    {
+        if (vertex->is_boundary()) boundary_vertices.insert(vertex);
+    }
+
+    // return
+    return boundary_vertices;
+}
+
+void Surface::try_close_holes()
+{
+    // boundary vertices
+    std::unordered_set<std::shared_ptr<Vertex>, MeshObjectHash> boundary_vertices = get_boundary_vertices();
+
+    // for each boundary vertex
+    for (const auto& vertex : boundary_vertices)
+    {
+        // skip if not longer boundary
+        if (!vertex->is_boundary()) continue;
+
+        // get connected boundary vertices
+        std::unordered_set<std::shared_ptr<Vertex>, MeshObjectHash> connected_boundary_vertices = vertex->get_connected_boundary_vertices();
+
+        // skip if not two connected boundary vertices
+        if (connected_boundary_vertices.size() != 2) continue;
+
+        // get the two connected boundary vertices
+        auto it = connected_boundary_vertices.begin();
+        std::shared_ptr<Vertex> vertex0 = *it;
+        std::shared_ptr<Vertex> vertex1 = *(++it);
+
+        // skip if edge is not short enough
+        double edge_length = (vertex0->get_position() - vertex1->get_position()).norm();
+        if (edge_length > vertex0->get_radius() || edge_length > vertex1->get_radius()) continue;
+
+        // skip if edge intersects
+        if (edge_bvh_.tree_intersect_edge(vertex0, vertex1)) continue;
+
+        // create edge if edge does not exist
+        const bool edge_exist = vertex0->check_connected_by_edge(vertex1);
+        if (!edge_exist)
+        {
+            std::shared_ptr<Edge> new_edge = storage_->add_edge(vertex0, vertex1);
+            connect(new_edge);
+        }
+
+        // create face if face does not exist
+        const bool face_exist = vertex->check_connected_by_face(vertex0, vertex1);
+        if (!face_exist)
+        {
+            std::shared_ptr<Face> new_face = storage_->add_face(shared_from_this(), vertex, vertex0, vertex1);
+            connect(new_face);
+        }
+    }
+}
+
 void Surface::swap(const std::shared_ptr<Vertex>& vertex1, const std::shared_ptr<Vertex>& vertex2)
 {
     // if contains vertex1

--- a/src/MeshObject/Surface.cpp
+++ b/src/MeshObject/Surface.cpp
@@ -695,17 +695,11 @@ bool Surface::connect_by_edges_and_faces(const std::shared_ptr<Vertex>& vertex, 
     std::unordered_set<std::shared_ptr<Face>, MeshObjectHash> new_faces;
     for (const auto& edge0 : new_edges)
     {
-        // skip if edge0 is not boundary
-        if (!edge0->is_boundary()) continue;
-
         // get vertex0
         std::shared_ptr<Vertex> vertex0 = edge0->get_vertex(0) != vertex ? edge0->get_vertex(0) : edge0->get_vertex(1);
 
         for (const auto& edge1 : new_edges)
-        {
-            // skip if edge1 is not boundary
-            if (!edge0->is_boundary()) continue;
-            
+        {            
             // get vertex1
             std::shared_ptr<Vertex> vertex1 = edge1->get_vertex(0) != vertex ? edge1->get_vertex(0) : edge1->get_vertex(1);
 
@@ -729,6 +723,10 @@ bool Surface::connect_by_edges_and_faces(const std::shared_ptr<Vertex>& vertex, 
 
             // skip if edge is not boundary
             if (!existing_edge->is_boundary()) continue;
+            // skip if edge0 is not boundary
+            if (!edge0->is_boundary()) continue;
+            // skip if edge1 is not boundary
+            if (!edge0->is_boundary()) continue;
 
             // create face
             std::shared_ptr<Face> new_face = storage_->add_face(shared_from_this(), vertex, vertex0, vertex1);

--- a/src/MeshObject/Surface.cpp
+++ b/src/MeshObject/Surface.cpp
@@ -982,6 +982,17 @@ void Surface::try_close_holes()
     }
 }
 
+void Surface::remove_non_manifold_edges()
+{
+    // make copy of edges
+    std::unordered_set<std::shared_ptr<Edge>, MeshObjectHash> edges_copy = edges_;
+
+    for (const auto& edge : edges_copy)
+    {
+        if (edge->is_non_manifold()) disconnect(edge);
+    }
+}
+
 void Surface::swap(const std::shared_ptr<Vertex>& vertex1, const std::shared_ptr<Vertex>& vertex2)
 {
     // if contains vertex1

--- a/src/MeshObject/Surface.cpp
+++ b/src/MeshObject/Surface.cpp
@@ -649,9 +649,6 @@ bool Surface::tree_intersect_edge(const std::shared_ptr<Vertex>& vertex0, const 
 
 bool Surface::connect_by_edges_and_faces(const std::shared_ptr<Vertex>& vertex, const std::unordered_set<std::shared_ptr<Vertex>, MeshObjectHash>& all_nearby_vertices)
 {
-    // initialize
-    bool connected = false;
-
     // get nearby vertices in the same surface
     std::unordered_set<std::shared_ptr<Vertex>, MeshObjectHash> nearby_vertices;
     for (const auto& nearby_vertex : all_nearby_vertices)
@@ -689,9 +686,6 @@ bool Surface::connect_by_edges_and_faces(const std::shared_ptr<Vertex>& vertex, 
 
         // store used vertices and new edges
         new_edges.insert(new_edge);
-
-        // update flag
-        connected = true;
     }
 
     // create faces
@@ -737,8 +731,9 @@ bool Surface::connect_by_edges_and_faces(const std::shared_ptr<Vertex>& vertex, 
         }
     }
 
-    // return
-    return connected;
+    // if new vertex have edges, return true, else return false
+    if (vertex->get_edges().size() > 0) return true;
+    else return false;
 }
 
 void Surface::compute_surface_position_std_in_normal_direction()

--- a/src/MeshObject/Surface.cpp
+++ b/src/MeshObject/Surface.cpp
@@ -732,7 +732,7 @@ bool Surface::connect_by_edges_and_faces(const std::shared_ptr<Vertex>& vertex, 
     }
 
     // false if new vertex don't have edges
-    if (new_edges.size() == 0) return false;
+    if (vertex->get_edges().empty()) return false;
     
     // false if surface have no boundary edges
     bool has_boundary_edges = false;

--- a/src/MeshObject/Surface.cpp
+++ b/src/MeshObject/Surface.cpp
@@ -723,7 +723,7 @@ bool Surface::connect_by_edges_and_faces(const std::shared_ptr<Vertex>& vertex, 
             // skip if edge0 is not boundary
             if (!edge0->is_boundary()) continue;
             // skip if edge1 is not boundary
-            if (!edge0->is_boundary()) continue;
+            if (!edge1->is_boundary()) continue;
 
             // create face
             std::shared_ptr<Face> new_face = storage_->add_face(shared_from_this(), vertex, vertex0, vertex1);

--- a/src/MeshObject/Surface.cpp
+++ b/src/MeshObject/Surface.cpp
@@ -733,6 +733,12 @@ bool Surface::connect_by_edges_and_faces(const std::shared_ptr<Vertex>& vertex, 
 
     // false if new vertex don't have edges
     if (vertex->get_edges().empty()) return false;
+
+    // false if new faces is non manifold
+    for (const auto& face : new_faces)
+    {
+        if (face->is_non_manifold()) return false;
+    }
     
     // false if surface have no boundary edges
     bool has_boundary_edges = false;

--- a/src/MeshObject/Surface.cpp
+++ b/src/MeshObject/Surface.cpp
@@ -642,6 +642,11 @@ void Surface::connect(const std::shared_ptr<Vertex>& vertex)
     }
 }
 
+bool Surface::tree_intersect_edge(const std::shared_ptr<Vertex>& vertex0, const std::shared_ptr<Vertex>& vertex1)
+{
+    return edge_bvh_.tree_intersect_edge(vertex0, vertex1);
+}
+
 bool Surface::connect_by_edges_and_faces(const std::shared_ptr<Vertex>& vertex, const std::unordered_set<std::shared_ptr<Vertex>, MeshObjectHash>& all_nearby_vertices)
 {
     // initialize
@@ -973,42 +978,7 @@ void Surface::try_close_holes()
     // for each boundary vertex
     for (const auto& vertex : boundary_vertices)
     {
-        // skip if not longer boundary
-        if (!vertex->is_boundary()) continue;
-
-        // get connected boundary vertices
-        std::unordered_set<std::shared_ptr<Vertex>, MeshObjectHash> connected_boundary_vertices = vertex->get_connected_boundary_vertices();
-
-        // skip if not two connected boundary vertices
-        if (connected_boundary_vertices.size() != 2) continue;
-
-        // get the two connected boundary vertices
-        auto it = connected_boundary_vertices.begin();
-        std::shared_ptr<Vertex> vertex0 = *it;
-        std::shared_ptr<Vertex> vertex1 = *(++it);
-
-        // skip if edge is not short enough
-        double edge_length = (vertex0->get_position() - vertex1->get_position()).norm();
-        if (edge_length > vertex0->get_radius() || edge_length > vertex1->get_radius()) continue;
-
-        // skip if edge intersects
-        if (edge_bvh_.tree_intersect_edge(vertex0, vertex1)) continue;
-
-        // create edge if edge does not exist
-        const bool edge_exist = vertex0->check_connected_by_edge(vertex1);
-        if (!edge_exist)
-        {
-            std::shared_ptr<Edge> new_edge = storage_->add_edge(vertex0, vertex1);
-            connect(new_edge);
-        }
-
-        // create face if face does not exist
-        const bool face_exist = vertex->check_connected_by_face(vertex0, vertex1);
-        if (!face_exist)
-        {
-            std::shared_ptr<Face> new_face = storage_->add_face(shared_from_this(), vertex, vertex0, vertex1);
-            connect(new_face);
-        }
+        vertex->try_close_holes();
     }
 }
 

--- a/src/MeshObject/Surface.cpp
+++ b/src/MeshObject/Surface.cpp
@@ -673,6 +673,9 @@ bool Surface::connect_by_edges_and_faces(const std::shared_ptr<Vertex>& vertex, 
     std::unordered_set<std::shared_ptr<Edge>, MeshObjectHash> new_edges;
     for (const auto& nearby_vertex : nearby_vertices)
     {
+        // skip if vertex is not boundary
+        if (!nearby_vertex->is_boundary()) continue;
+
         // skip if edge is longer than any of the radius of vertices
         double distance = (vertex->get_position() - nearby_vertex->get_position()).norm();
         if (distance > vertex->get_radius(shared_from_this()) || distance > nearby_vertex->get_radius()) continue;

--- a/src/MeshObject/Surface.cpp
+++ b/src/MeshObject/Surface.cpp
@@ -695,10 +695,18 @@ bool Surface::connect_by_edges_and_faces(const std::shared_ptr<Vertex>& vertex, 
     std::unordered_set<std::shared_ptr<Face>, MeshObjectHash> new_faces;
     for (const auto& edge0 : new_edges)
     {
+        // skip if edge0 is not boundary
+        if (!edge0->is_boundary()) continue;
+
+        // get vertex0
         std::shared_ptr<Vertex> vertex0 = edge0->get_vertex(0) != vertex ? edge0->get_vertex(0) : edge0->get_vertex(1);
 
         for (const auto& edge1 : new_edges)
         {
+            // skip if edge1 is not boundary
+            if (!edge0->is_boundary()) continue;
+            
+            // get vertex1
             std::shared_ptr<Vertex> vertex1 = edge1->get_vertex(0) != vertex ? edge1->get_vertex(0) : edge1->get_vertex(1);
 
             // skip if repeated

--- a/src/MeshObject/Surface.cpp
+++ b/src/MeshObject/Surface.cpp
@@ -678,22 +678,19 @@ bool Surface::connect_by_edges_and_faces(const std::shared_ptr<Vertex>& vertex, 
         double distance = (vertex->get_position() - nearby_vertex->get_position()).norm();
         if (distance > vertex->get_radius(shared_from_this()) || distance > nearby_vertex->get_radius()) continue;
 
-        // if edge intersects
-        if (edge_bvh_.tree_intersect_edge(vertex, nearby_vertex)) 
-        {   
-            // log
-            if (settings_.log.connect_by_edges_and_faces) std::cout << "Try to create edge between " << vertex->get_id() << " and " << nearby_vertex->get_id() << " but is intersected." << std::endl;
-        }
-        else // if edge does not intersect
-        {
-            // create edge
-            std::shared_ptr<Edge> new_edge = storage_->add_edge(vertex, nearby_vertex);
-            connect(new_edge);
-            used_vertices.insert(nearby_vertex);
-            new_edges.insert(new_edge);
+        // skip if edge intersects
+        if (edge_bvh_.tree_intersect_edge(vertex, nearby_vertex)) continue;
 
-            connected = true;
-        }
+        // create edge
+        std::shared_ptr<Edge> new_edge = storage_->add_edge(vertex, nearby_vertex);
+        connect(new_edge);
+
+        // store used vertices and new edges
+        used_vertices.insert(nearby_vertex);
+        new_edges.insert(new_edge);
+
+        // update flag
+        connected = true;
     }
 
     // create faces
@@ -742,38 +739,7 @@ bool Surface::connect_by_edges_and_faces(const std::shared_ptr<Vertex>& vertex, 
             }
             if (triangle_contains_nearby_vertices) continue;
 
-            // don't remove silver triangle, need better ways
-
-            // // skip if face is too thin (silver triangle)
-            // Eigen::Vector3d edge1 = nearby_vertex0->get_position() - vertex->get_position();
-            // Eigen::Vector3d edge2 = nearby_vertex1->get_position() - vertex->get_position();
-            // double angle = std::acos(edge1.normalized().dot(edge2.normalized())) * 180 / M_PI;
-            // if (angle < settings_.min_face_angle) continue;
-            // if (angle > (180 - 2.0*settings_.min_face_angle)) continue;
-
-
-            // // check if face already exists
-            // bool face_exist = false;
-            // std::shared_ptr<Face> existing_face;
-            // for (const std::shared_ptr<Face>& face : existing_edge->get_faces())
-            // {
-            //     if (face->has_vertex(vertex))
-            //     {
-            //         // log
-            //         std::cout << "Face already exists between " << vertex->get_id() << " and " << nearby_vertex0->get_id() << " and " << nearby_vertex1->get_id() << std::endl;
-                    
-            //         face_exist = true;
-            //         existing_face = face;
-            //         break;
-            //     }
-            // }
-            // if (face_exist)
-            // {
-            //     connect(existing_face);
-            //     continue;
-            // }
-
-            // if face not already exists, create face
+            // create face
             std::shared_ptr<Face> new_face = storage_->add_face(shared_from_this(), vertex, nearby_vertex0, nearby_vertex1);
             new_faces.insert(new_face);
         }

--- a/src/MeshObject/Vertex.cpp
+++ b/src/MeshObject/Vertex.cpp
@@ -678,6 +678,9 @@ bool Vertex::try_close_holes()
         changed = true;
     }
 
+    // skip if edge between 0 and 1 is not boundary
+    if (!vertex0->get_edge(vertex1)->is_boundary()) return changed;
+
     // create face if face does not exist
     const bool face_exist = check_connected_by_face(vertex0, vertex1);
     if (!face_exist)

--- a/src/MeshObject/Vertex.cpp
+++ b/src/MeshObject/Vertex.cpp
@@ -742,6 +742,15 @@ void Vertex::delete_self_from_nearby_vertices()
             continue;
         }
 
+        // try lock the surface
+        std::shared_ptr<Surface> surface_copy = neighboring_vertex->get_surface();
+        if (!omp_test_nest_lock(&surface_copy->lock)) 
+        {
+            // release vertex lock
+            omp_unset_nest_lock(&neighboring_vertex->vertex_lock);
+            continue;
+        }
+
         // delete from neighboring vertex
         neighboring_vertex->delete_nearby_vertex(shared_from_this());        
 
@@ -754,6 +763,7 @@ void Vertex::delete_self_from_nearby_vertices()
         {
             // release lock
             omp_unset_nest_lock(&neighboring_vertex->vertex_lock);
+            omp_unset_nest_lock(&surface_copy->lock);
             continue;
         }
 
@@ -762,6 +772,7 @@ void Vertex::delete_self_from_nearby_vertices()
 
         // release lock
         omp_unset_nest_lock(&neighboring_vertex->vertex_lock);
+        omp_unset_nest_lock(&surface_copy->lock);
     }
 }
 
@@ -831,6 +842,15 @@ void Vertex::delete_self_from_penetrating_vertex_points()
             continue;
         }
 
+        // try lock the surface
+        std::shared_ptr<Surface> surface_copy = vertex->get_surface();
+        if (!omp_test_nest_lock(&surface_copy->lock)) 
+        {
+            // release vertex lock
+            omp_unset_nest_lock(&vertex->vertex_lock);
+            continue;
+        }
+
         // delete from neighboring vertex
         vertex->delete_penetrated_vertex(shared_from_this());
 
@@ -843,6 +863,7 @@ void Vertex::delete_self_from_penetrating_vertex_points()
         {
             // release lock
             omp_unset_nest_lock(&vertex->vertex_lock);
+            omp_unset_nest_lock(&surface_copy->lock);
             continue;
         }
 
@@ -851,6 +872,7 @@ void Vertex::delete_self_from_penetrating_vertex_points()
 
         // release lock
         omp_unset_nest_lock(&vertex->vertex_lock);
+        omp_unset_nest_lock(&surface_copy->lock);
     }
 }
 
@@ -920,6 +942,15 @@ void Vertex::delete_self_from_penetrated_vertices()
             continue;
         }
 
+        // try lock the surface
+        std::shared_ptr<Surface> surface_copy = vertex->get_surface();
+        if (!omp_test_nest_lock(&surface_copy->lock)) 
+        {
+            // release vertex lock
+            omp_unset_nest_lock(&vertex->vertex_lock);
+            continue;
+        }
+
         // delete from neighboring vertex
         vertex->delete_penetrating_vertex_point(shared_from_this());
 
@@ -932,6 +963,7 @@ void Vertex::delete_self_from_penetrated_vertices()
         {
             // release lock
             omp_unset_nest_lock(&vertex->vertex_lock);
+            omp_unset_nest_lock(&surface_copy->lock);
             continue;
         }
 
@@ -940,6 +972,7 @@ void Vertex::delete_self_from_penetrated_vertices()
 
         // release lock
         omp_unset_nest_lock(&vertex->vertex_lock);
+        omp_unset_nest_lock(&surface_copy->lock);
     }
 }
 

--- a/src/MeshObject/Vertex.cpp
+++ b/src/MeshObject/Vertex.cpp
@@ -767,6 +767,9 @@ void Vertex::delete_self_from_nearby_vertices()
             continue;
         }
 
+        // try close holes
+        neighboring_vertex->try_close_holes_repeatedly();
+
         // try update
         neighboring_vertex->try_update_node_box();
 
@@ -867,6 +870,9 @@ void Vertex::delete_self_from_penetrating_vertex_points()
             continue;
         }
 
+        // try close holes
+        vertex->try_close_holes_repeatedly();
+
         // try update
         vertex->try_update_node_box();
 
@@ -966,6 +972,9 @@ void Vertex::delete_self_from_penetrated_vertices()
             omp_unset_nest_lock(&surface_copy->lock);
             continue;
         }
+
+        // try close holes
+        vertex->try_close_holes_repeatedly();
 
         // try update
         vertex->try_update_node_box();

--- a/src/MeshObject/Vertex.cpp
+++ b/src/MeshObject/Vertex.cpp
@@ -632,14 +632,17 @@ bool Vertex::try_close_holes_repeatedly()
 
 bool Vertex::try_close_holes()
 {
+    // changed flag
+    bool changed = false;
+
     // skip if not longer boundary
-    if (!is_boundary()) return false;
+    if (!is_boundary()) return changed;
 
     // get connected boundary vertices
     std::unordered_set<std::shared_ptr<Vertex>, MeshObjectHash> connected_boundary_vertices = get_connected_boundary_vertices();
 
     // skip if not two connected boundary vertices
-    if (connected_boundary_vertices.size() != 2) return false;
+    if (connected_boundary_vertices.size() != 2) return changed;
 
     // get the two connected boundary vertices
     auto it = connected_boundary_vertices.begin();
@@ -648,36 +651,37 @@ bool Vertex::try_close_holes()
 
     // skip if edge is not short enough
     double edge_length = (vertex0->get_position() - vertex1->get_position()).norm();
-    if (edge_length > vertex0->get_radius() || edge_length > vertex1->get_radius()) return false;
+    if (edge_length > vertex0->get_radius() || edge_length > vertex1->get_radius()) return changed;
 
     // skip if edge intersects
-    if (get_surface()->tree_intersect_edge(vertex0, vertex1)) return false;
+    if (get_surface()->tree_intersect_edge(vertex0, vertex1)) return changed;
 
     // create edge if edge does not exist
     const bool edge_exist = vertex0->check_connected_by_edge(vertex1);
     if (!edge_exist)
     {
+        // create edge
         std::shared_ptr<Edge> new_edge = storage_->add_edge(vertex0, vertex1);
         get_surface()->connect(new_edge);
+
+        // update flag
+        changed = true;
     }
 
     // create face if face does not exist
     const bool face_exist = check_connected_by_face(vertex0, vertex1);
     if (!face_exist)
     {
+        // create face
         std::shared_ptr<Face> new_face = storage_->add_face(get_surface(), shared_from_this(), vertex0, vertex1);
         get_surface()->connect(new_face);
+
+        // update flag
+        changed = true;
     }
 
-    // if anything changed, return true
-    if (!edge_exist || !face_exist) 
-    {
-        return true;
-    }
-    else
-    {
-        return false;
-    }
+    // return changed
+    return changed;
 }
 
 void Vertex::remove_all_edges()

--- a/src/MeshObject/Vertex.cpp
+++ b/src/MeshObject/Vertex.cpp
@@ -689,8 +689,36 @@ bool Vertex::try_close_holes()
         std::shared_ptr<Face> new_face = storage_->add_face(get_surface(), shared_from_this(), vertex0, vertex1);
         get_surface()->connect(new_face);
 
-        // update flag
-        changed = true;
+        // un-add the face if face is non-manifold
+        if (new_face->is_non_manifold())
+        {
+            // set can self destruct
+            set_can_self_destruct(false);
+            vertex0->set_can_self_destruct(false);
+            vertex1->set_can_self_destruct(false);
+            get_edge(vertex0)->set_can_self_destruct(false);
+            get_edge(vertex1)->set_can_self_destruct(false);
+            vertex0->get_edge(vertex1)->set_can_self_destruct(false);
+
+            // delete face
+            storage_->delete_face(new_face);
+
+            // set can self destruct
+            set_can_self_destruct(true);
+            vertex0->set_can_self_destruct(true);
+            vertex1->set_can_self_destruct(true);
+            get_edge(vertex0)->set_can_self_destruct(true);
+            get_edge(vertex1)->set_can_self_destruct(true);
+            vertex0->get_edge(vertex1)->set_can_self_destruct(true);
+
+            // update flag
+            changed = false;
+        }
+        else
+        {
+            // update flag
+            changed = true;
+        }
     }
 
     // return changed

--- a/src/MeshObject/Vertex.cpp
+++ b/src/MeshObject/Vertex.cpp
@@ -267,6 +267,16 @@ double& Vertex::get_projected_uncertainty()
     return projected_uncertainty_;
 }
 
+const std::shared_ptr<Edge>& Vertex::get_edge(const std::shared_ptr<Vertex>& vertex) const
+{
+    for (const std::shared_ptr<Edge>& edge : edges_)
+    {
+        if (edge->has_vertex(vertex)) return edge;
+    }
+
+    throw std::runtime_error("Edge not found.");
+}
+
 // void Vertex::try_merge_surfaces()
 // {
     // // check if there is only one surface

--- a/src/MeshObject/Vertex.cpp
+++ b/src/MeshObject/Vertex.cpp
@@ -713,22 +713,59 @@ bool Vertex::try_close_holes_between_self_and(std::shared_ptr<Vertex>& vertex0, 
 
 bool Vertex::try_close_holes()
 {
-    // skip if not longer boundary
-    if (!is_boundary()) return false;
+    // initialize
+    bool changed = false;
 
-    // get connected boundary vertices
-    std::unordered_set<std::shared_ptr<Vertex>, MeshObjectHash> connected_boundary_vertices = get_connected_boundary_vertices();
+    // initialize
+    bool repeat_loop = true;
+    while (repeat_loop)
+    {
+        repeat_loop = false;
 
-    // skip if not two connected boundary vertices
-    if (connected_boundary_vertices.size() != 2) return false;
+        // get connected boundary vertices
+        std::unordered_set<std::shared_ptr<Vertex>, MeshObjectHash> connected_boundary_vertices = get_connected_boundary_vertices();
 
-    // get the two connected boundary vertices
-    auto it = connected_boundary_vertices.begin();
-    std::shared_ptr<Vertex> vertex0 = *it;
-    std::shared_ptr<Vertex> vertex1 = *(++it);
+        // skip if less than two connected boundary vertex (this includes when the vertex itself is not boundary)
+        if (connected_boundary_vertices.size() < 2)
+        {
+            break;
+        }
 
-    // try close holes between the two vertices
-    return try_close_holes_between_self_and(vertex0, vertex1);
+        // compute connected boundary vertices with angle
+        std::vector<std::pair<std::shared_ptr<Vertex>, double>> connected_boundary_vertices_with_angle;
+        for (const auto& vertex : connected_boundary_vertices)
+        {
+            // use projected position
+            Eigen::Vector2d direction = vertex->get_surface_coordinate() - get_surface_coordinate();
+            double angle = std::atan2(direction.y(), direction.x());
+
+            // add to list
+            connected_boundary_vertices_with_angle.push_back(std::make_pair(vertex, angle));
+        }
+
+        // sort by angle
+        std::sort(connected_boundary_vertices_with_angle.begin(), connected_boundary_vertices_with_angle.end(), [](const std::pair<std::shared_ptr<Vertex>, double>& a, const std::pair<std::shared_ptr<Vertex>, double>& b) { return a.second < b.second; });
+
+        // create pairs of connected boundary vertices
+        std::vector<std::pair<std::shared_ptr<Vertex>, std::shared_ptr<Vertex>>> connected_boundary_vertex_pairs;
+        for (int i = 0; i < connected_boundary_vertices_with_angle.size(); i++)
+        {
+            connected_boundary_vertex_pairs.push_back(std::make_pair(connected_boundary_vertices_with_angle[i].first, connected_boundary_vertices_with_angle[(i + 1) % connected_boundary_vertices_with_angle.size()].first));
+        }
+
+        // try close holes between the two vertices
+        for (auto& [vertex0, vertex1] : connected_boundary_vertex_pairs)
+        {
+            if (try_close_holes_between_self_and(vertex0, vertex1)) 
+            {
+                changed = true;
+                repeat_loop = true;
+                break;
+            }
+        }
+    }
+
+    return changed;
 }
 
 void Vertex::remove_all_edges()

--- a/src/MeshObject/Vertex.cpp
+++ b/src/MeshObject/Vertex.cpp
@@ -640,24 +640,10 @@ bool Vertex::try_close_holes_repeatedly()
     return changed;
 }
 
-bool Vertex::try_close_holes()
+bool Vertex::try_close_holes_between_self_and(std::shared_ptr<Vertex>& vertex0, std::shared_ptr<Vertex>& vertex1) 
 {
-    // changed flag
+    // initialize flag
     bool changed = false;
-
-    // skip if not longer boundary
-    if (!is_boundary()) return changed;
-
-    // get connected boundary vertices
-    std::unordered_set<std::shared_ptr<Vertex>, MeshObjectHash> connected_boundary_vertices = get_connected_boundary_vertices();
-
-    // skip if not two connected boundary vertices
-    if (connected_boundary_vertices.size() != 2) return changed;
-
-    // get the two connected boundary vertices
-    auto it = connected_boundary_vertices.begin();
-    std::shared_ptr<Vertex> vertex0 = *it;
-    std::shared_ptr<Vertex> vertex1 = *(++it);
 
     // skip if edge is not short enough
     double edge_length = (vertex0->get_position() - vertex1->get_position()).norm();
@@ -723,6 +709,26 @@ bool Vertex::try_close_holes()
 
     // return changed
     return changed;
+}
+
+bool Vertex::try_close_holes()
+{
+    // skip if not longer boundary
+    if (!is_boundary()) return false;
+
+    // get connected boundary vertices
+    std::unordered_set<std::shared_ptr<Vertex>, MeshObjectHash> connected_boundary_vertices = get_connected_boundary_vertices();
+
+    // skip if not two connected boundary vertices
+    if (connected_boundary_vertices.size() != 2) return false;
+
+    // get the two connected boundary vertices
+    auto it = connected_boundary_vertices.begin();
+    std::shared_ptr<Vertex> vertex0 = *it;
+    std::shared_ptr<Vertex> vertex1 = *(++it);
+
+    // try close holes between the two vertices
+    return try_close_holes_between_self_and(vertex0, vertex1);
 }
 
 void Vertex::remove_all_edges()

--- a/src/MeshObject/Vertex.cpp
+++ b/src/MeshObject/Vertex.cpp
@@ -682,8 +682,10 @@ bool Vertex::try_close_holes()
 
 bool Vertex::is_non_manifold() const
 {
-    // check if connected by more than 2 boundary edges
-    return get_connected_boundary_edges().size() > 2;
+    // non manifold if 
+    // 1. connected by one boundary edge
+    // 2. connected by more than 2 boundary edges
+    return get_connected_boundary_edges().size() > 2 || get_connected_boundary_edges().size() == 1;
 }
 
 void Vertex::add_nearby_vertex(const std::shared_ptr<Vertex>& rrs_vertex)

--- a/src/MeshObject/Vertex.cpp
+++ b/src/MeshObject/Vertex.cpp
@@ -501,7 +501,7 @@ void Vertex::disconnect(const std::shared_ptr<Edge>& edge)
     check_if_update_search_tree();
 
     // check self destruct
-    if (!deleting_ && edges_.empty()) storage_->delete_vertex(shared_from_this());
+    if (!deleting_ && edges_.empty() && can_self_destruct_) storage_->delete_vertex(shared_from_this());
 }
 
 void Vertex::disconnect(const std::shared_ptr<Face>& face)
@@ -678,6 +678,23 @@ bool Vertex::try_close_holes()
     {
         return false;
     }
+}
+
+void Vertex::remove_all_edges()
+{
+    // make copy of edges
+    std::unordered_set<std::shared_ptr<Edge>, MeshObjectHash> edges_copy = edges_;
+
+    // remove all edges
+    for (const auto& edge : edges_copy)
+    {
+        disconnect(edge);
+    }
+}
+
+void Vertex::set_can_self_destruct(bool can_self_destruct)
+{
+    can_self_destruct_ = can_self_destruct;
 }
 
 bool Vertex::is_non_manifold() const

--- a/src/MeshObject/Vertex.cpp
+++ b/src/MeshObject/Vertex.cpp
@@ -558,6 +558,63 @@ void Vertex::disconnect(const std::shared_ptr<Vertex>& sibling_vertex)
     if (erased) sibling_vertex->disconnect(shared_from_this());
 }
 
+std::unordered_set<std::shared_ptr<Edge>, MeshObjectHash> Vertex::get_connected_boundary_edges()
+{
+    // initialize
+    std::unordered_set<std::shared_ptr<Edge>, MeshObjectHash> connected_boundary_edges;
+
+    // get boundary edges
+    for (const auto& edge : get_edges())
+    {
+        if (edge->is_boundary()) connected_boundary_edges.insert(edge);
+    }
+
+    // return
+    return connected_boundary_edges;
+}
+
+std::unordered_set<std::shared_ptr<Vertex>, MeshObjectHash> Vertex::get_connected_boundary_vertices()
+{
+    // get connected boundary edges
+    std::unordered_set<std::shared_ptr<Edge>, MeshObjectHash> connected_boundary_edges = get_connected_boundary_edges();
+
+    // get connected boundary vertices
+    std::unordered_set<std::shared_ptr<Vertex>, MeshObjectHash> connected_boundary_vertices;
+    for (const auto& edge : connected_boundary_edges)
+    {
+        connected_boundary_vertices.insert(edge->get_vertex(0));
+        connected_boundary_vertices.insert(edge->get_vertex(1));
+    }
+    connected_boundary_vertices.erase(shared_from_this()); // remove self
+
+    // return
+    return connected_boundary_vertices;
+}
+
+bool Vertex::check_connected_by_edge(const std::shared_ptr<Vertex>& vertex)
+{
+    // check if connected by edge
+    for (const auto& edge : edges_)
+    {
+        if (edge->get_vertex(0) == vertex || edge->get_vertex(1) == vertex) return true;
+    }
+
+    // return
+    return false;
+}
+
+bool Vertex::check_connected_by_face(const std::shared_ptr<Vertex>& vertex0, const std::shared_ptr<Vertex>& vertex1)
+{
+    // check if connected by face
+    for (const auto& face : faces_)
+    {
+        if (face->has_vertex(vertex0) && face->has_vertex(vertex1)) return true;
+    }
+
+    // return
+    return false;
+}
+
 void Vertex::add_nearby_vertex(const std::shared_ptr<Vertex>& rrs_vertex)
 {
     // check input 

--- a/src/MeshObject/Vertex.cpp
+++ b/src/MeshObject/Vertex.cpp
@@ -558,7 +558,7 @@ void Vertex::disconnect(const std::shared_ptr<Vertex>& sibling_vertex)
     if (erased) sibling_vertex->disconnect(shared_from_this());
 }
 
-std::unordered_set<std::shared_ptr<Edge>, MeshObjectHash> Vertex::get_connected_boundary_edges()
+std::unordered_set<std::shared_ptr<Edge>, MeshObjectHash> Vertex::get_connected_boundary_edges() const
 {
     // initialize
     std::unordered_set<std::shared_ptr<Edge>, MeshObjectHash> connected_boundary_edges;
@@ -678,6 +678,12 @@ bool Vertex::try_close_holes()
     {
         return false;
     }
+}
+
+bool Vertex::is_non_manifold() const
+{
+    // check if connected by more than 2 boundary edges
+    return get_connected_boundary_edges().size() > 2;
 }
 
 void Vertex::add_nearby_vertex(const std::shared_ptr<Vertex>& rrs_vertex)

--- a/src/MeshObject/Vertex.cpp
+++ b/src/MeshObject/Vertex.cpp
@@ -615,6 +615,21 @@ bool Vertex::check_connected_by_face(const std::shared_ptr<Vertex>& vertex0, con
     return false;
 }
 
+bool Vertex::try_close_holes_repeatedly()
+{
+    // initialize
+    bool changed = false;
+
+    // try close holes repeatedly
+    while (try_close_holes()) 
+    {
+        changed = true;
+    }
+
+    // return
+    return changed;
+}
+
 bool Vertex::try_close_holes()
 {
     // skip if not longer boundary

--- a/src/MeshObject/Vertex.cpp
+++ b/src/MeshObject/Vertex.cpp
@@ -615,6 +615,56 @@ bool Vertex::check_connected_by_face(const std::shared_ptr<Vertex>& vertex0, con
     return false;
 }
 
+bool Vertex::try_close_holes()
+{
+    // skip if not longer boundary
+    if (!is_boundary()) return false;
+
+    // get connected boundary vertices
+    std::unordered_set<std::shared_ptr<Vertex>, MeshObjectHash> connected_boundary_vertices = get_connected_boundary_vertices();
+
+    // skip if not two connected boundary vertices
+    if (connected_boundary_vertices.size() != 2) return false;
+
+    // get the two connected boundary vertices
+    auto it = connected_boundary_vertices.begin();
+    std::shared_ptr<Vertex> vertex0 = *it;
+    std::shared_ptr<Vertex> vertex1 = *(++it);
+
+    // skip if edge is not short enough
+    double edge_length = (vertex0->get_position() - vertex1->get_position()).norm();
+    if (edge_length > vertex0->get_radius() || edge_length > vertex1->get_radius()) return false;
+
+    // skip if edge intersects
+    if (get_surface()->tree_intersect_edge(vertex0, vertex1)) return false;
+
+    // create edge if edge does not exist
+    const bool edge_exist = vertex0->check_connected_by_edge(vertex1);
+    if (!edge_exist)
+    {
+        std::shared_ptr<Edge> new_edge = storage_->add_edge(vertex0, vertex1);
+        get_surface()->connect(new_edge);
+    }
+
+    // create face if face does not exist
+    const bool face_exist = check_connected_by_face(vertex0, vertex1);
+    if (!face_exist)
+    {
+        std::shared_ptr<Face> new_face = storage_->add_face(get_surface(), shared_from_this(), vertex0, vertex1);
+        get_surface()->connect(new_face);
+    }
+
+    // if anything changed, return true
+    if (!edge_exist || !face_exist) 
+    {
+        return true;
+    }
+    else
+    {
+        return false;
+    }
+}
+
 void Vertex::add_nearby_vertex(const std::shared_ptr<Vertex>& rrs_vertex)
 {
     // check input 


### PR DESCRIPTION
### Changes
- Added the `try_close_hole` function for handling vertex connections.
- Enhanced the process of adding a vertex to a surface by introducing checks to identify and remove:
  - Non-manifold vertices (vertices with more than two boundary edges).
  - Non-manifold edges (edges shared by more than two faces).
  - Non-manifold faces (faces forming a closed ball).